### PR TITLE
Add Robinhood Testnet to uptime monitoring

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -93,6 +93,8 @@ sites:
     url: https://api.safe.global/tx-service/tempo/check/
   - name: Safe Tx Service (Fluent)
     url: https://api.safe.global/tx-service/fluent/check/
+  - name: Safe Tx Service (Robinhood Testnet)
+    url: https://api.safe.global/tx-service/robinhood-testnet/check/
 status-website:
   # Add your custom domain name, or remove the `cname` line if you don't have a domain
   # Uncomment the `baseUrl` line if you don't have a custom domain and add your repo name there

--- a/history/safe-client-gateway.yml
+++ b/history/safe-client-gateway.yml
@@ -1,7 +1,7 @@
 url: https://safe-client.safe.global/health/ready/
 status: up
 code: 200
-responseTime: 291
-lastUpdated: 2026-04-12T23:10:16.731Z
+responseTime: 179
+lastUpdated: 2026-04-13T11:39:59.792Z
 startTime: 2024-06-14T14:46:50.293Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-0g.yml
+++ b/history/safe-tx-service-0g.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/0g/check/
 status: up
 code: 200
-responseTime: 311
-lastUpdated: 2026-04-12T23:10:39.012Z
+responseTime: 312
+lastUpdated: 2026-04-13T11:40:18.475Z
 startTime: 2025-11-19T09:51:42.016Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arbitrum.yml
+++ b/history/safe-tx-service-arbitrum.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-arbitrum.safe.global/check/
 status: up
 code: 200
-responseTime: 325
-lastUpdated: 2026-04-12T23:10:22.659Z
+responseTime: 388
+lastUpdated: 2026-04-13T11:40:06.334Z
 startTime: 2021-08-05T10:30:22.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arc-testnet.yml
+++ b/history/safe-tx-service-arc-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/arc-testnet/check/
 status: up
 code: 200
-responseTime: 301
-lastUpdated: 2026-04-12T23:10:41.509Z
+responseTime: 313
+lastUpdated: 2026-04-13T11:40:20.975Z
 startTime: 2026-01-16T19:30:22.108Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-aurora.yml
+++ b/history/safe-tx-service-aurora.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-aurora.safe.global/check/
 status: up
 code: 200
-responseTime: 332
-lastUpdated: 2026-04-12T23:10:24.774Z
+responseTime: 326
+lastUpdated: 2026-04-13T11:40:07.853Z
 startTime: 2024-03-19T10:34:30.573Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-avalanche.yml
+++ b/history/safe-tx-service-avalanche.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-avalanche.safe.global/check/
 status: up
 code: 200
-responseTime: 410
-lastUpdated: 2026-04-12T23:10:23.609Z
+responseTime: 315
+lastUpdated: 2026-04-13T11:40:06.835Z
 startTime: 2022-03-25T11:57:26.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-base-mainnet.yml
+++ b/history/safe-tx-service-base-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-base.safe.global/check/
 status: up
 code: 200
-responseTime: 331
-lastUpdated: 2026-04-12T23:10:21.089Z
+responseTime: 312
+lastUpdated: 2026-04-13T11:40:04.737Z
 startTime: 2024-06-14T14:46:55.924Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-base-sepolia.yml
+++ b/history/safe-tx-service-base-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-base-sepolia.safe.global/check/
 status: up
 code: 200
-responseTime: 322
-lastUpdated: 2026-04-12T23:10:21.598Z
+responseTime: 332
+lastUpdated: 2026-04-13T11:40:05.257Z
 startTime: 2024-03-19T10:34:27.349Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-berachain.yml
+++ b/history/safe-tx-service-berachain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-berachain.safe.global/check/
 status: up
 code: 200
-responseTime: 305
-lastUpdated: 2026-04-12T23:10:30.016Z
+responseTime: 323
+lastUpdated: 2026-04-13T11:40:12.907Z
 startTime: 2025-02-17T09:20:55.646Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-binance-smart-chain.yml
+++ b/history/safe-tx-service-binance-smart-chain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-bsc.safe.global/check/
 status: up
 code: 200
-responseTime: 329
-lastUpdated: 2026-04-12T23:10:19.222Z
+responseTime: 322
+lastUpdated: 2026-04-13T11:40:02.741Z
 startTime: 2021-08-05T10:30:17.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-botanix.yml
+++ b/history/safe-tx-service-botanix.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-botanix.safe.global/check/
 status: up
 code: 200
-responseTime: 336
-lastUpdated: 2026-04-12T23:10:37.390Z
+responseTime: 313
+lastUpdated: 2026-04-13T11:40:16.977Z
 startTime: 2025-08-27T12:42:17.067Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-celo.yml
+++ b/history/safe-tx-service-celo.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-celo.safe.global/check/
 status: up
 code: 200
-responseTime: 335
-lastUpdated: 2026-04-12T23:10:22.123Z
+responseTime: 312
+lastUpdated: 2026-04-13T11:40:05.759Z
 startTime: 2023-05-23T15:39:32.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-chiado.yml
+++ b/history/safe-tx-service-chiado.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-chiado.safe.global/check/
 status: up
 code: 200
-responseTime: 371
-lastUpdated: 2026-04-12T23:10:27.366Z
+responseTime: 313
+lastUpdated: 2026-04-13T11:40:10.395Z
 startTime: 2024-08-16T10:52:40.346Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-codex.yml
+++ b/history/safe-tx-service-codex.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-codex.safe.global/check/
 status: up
 code: 200
-responseTime: 430
-lastUpdated: 2026-04-12T23:10:35.766Z
+responseTime: 327
+lastUpdated: 2026-04-13T11:40:15.446Z
 startTime: 2025-07-15T12:51:17.948Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-creditcoin.yml
+++ b/history/safe-tx-service-creditcoin.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/ctc/check/
 status: up
 code: 200
-responseTime: 311
-lastUpdated: 2026-04-12T23:10:42.010Z
+responseTime: 309
+lastUpdated: 2026-04-13T11:40:21.476Z
 startTime: 2026-03-06T09:26:54.038Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-fluent.yml
+++ b/history/safe-tx-service-fluent.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/fluent/check/
 status: up
 code: 200
-responseTime: 308
-lastUpdated: 2026-04-12T23:10:44.011Z
+responseTime: 312
+lastUpdated: 2026-04-13T11:40:23.474Z
 startTime: 2026-04-08T07:35:21.962Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-gnosis-chain.yml
+++ b/history/safe-tx-service-gnosis-chain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-gnosis-chain.safe.global/check/
 status: up
 code: 200
-responseTime: 398
-lastUpdated: 2026-04-12T23:10:18.096Z
+responseTime: 315
+lastUpdated: 2026-04-13T11:40:01.363Z
 startTime: 2022-12-21T17:20:44.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-hemi.yml
+++ b/history/safe-tx-service-hemi.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-hemi.safe.global/check/
 status: up
 code: 200
-responseTime: 330
-lastUpdated: 2026-04-12T23:10:31.137Z
+responseTime: 310
+lastUpdated: 2026-04-13T11:40:13.921Z
 startTime: 2025-04-29T10:31:54.263Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-hyper-evm.yml
+++ b/history/safe-tx-service-hyper-evm.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/hyper/check/
 status: up
 code: 200
-responseTime: 306
-lastUpdated: 2026-04-12T23:10:40.508Z
+responseTime: 313
+lastUpdated: 2026-04-13T11:40:19.975Z
 startTime: 2025-11-19T09:51:43.815Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-ink.yml
+++ b/history/safe-tx-service-ink.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-ink.safe.global/check/
 status: up
 code: 200
-responseTime: 327
-lastUpdated: 2026-04-12T23:10:28.991Z
+responseTime: 313
+lastUpdated: 2026-04-13T11:40:11.894Z
 startTime: 2024-12-12T17:15:05.125Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-katana.yml
+++ b/history/safe-tx-service-katana.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-katana.safe.global/check/
 status: up
 code: 200
-responseTime: 3304
-lastUpdated: 2026-04-12T23:10:34.632Z
+responseTime: 315
+lastUpdated: 2026-04-13T11:40:14.425Z
 startTime: 2025-06-12T12:51:37.947Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-lens.yml
+++ b/history/safe-tx-service-lens.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-lens.safe.global/check/
 status: up
 code: 200
-responseTime: 393
-lastUpdated: 2026-04-12T23:10:30.615Z
+responseTime: 331
+lastUpdated: 2026-04-13T11:40:13.424Z
 startTime: 2025-04-29T10:31:53.750Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-linea.yml
+++ b/history/safe-tx-service-linea.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-linea.safe.global/check/
 status: up
 code: 200
-responseTime: 304
-lastUpdated: 2026-04-12T23:10:26.802Z
+responseTime: 318
+lastUpdated: 2026-04-13T11:40:09.893Z
 startTime: 2024-08-13T14:27:58.910Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mainnet.yml
+++ b/history/safe-tx-service-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-mainnet.safe.global/check/
 status: up
 code: 200
-responseTime: 549
-lastUpdated: 2026-04-12T23:10:17.510Z
+responseTime: 873
+lastUpdated: 2026-04-13T11:40:00.857Z
 startTime: 2021-08-05T10:30:13.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mantle-sepolia.yml
+++ b/history/safe-tx-service-mantle-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/mnt-sep/check/
 status: up
 code: 200
-responseTime: 311
-lastUpdated: 2026-04-12T23:10:42.512Z
+responseTime: 312
+lastUpdated: 2026-04-13T11:40:21.976Z
 startTime: 2026-03-09T14:14:37.684Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mantle.yml
+++ b/history/safe-tx-service-mantle.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-mantle.safe.global/check/
 status: up
 code: 200
-responseTime: 328
-lastUpdated: 2026-04-12T23:10:27.885Z
+responseTime: 312
+lastUpdated: 2026-04-13T11:40:10.897Z
 startTime: 2024-09-23T12:22:22.690Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mega-eth.yml
+++ b/history/safe-tx-service-mega-eth.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/mega/check/
 status: up
 code: 200
-responseTime: 319
-lastUpdated: 2026-04-12T23:10:41.018Z
+responseTime: 312
+lastUpdated: 2026-04-13T11:40:20.476Z
 startTime: 2025-11-19T09:51:44.285Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-monad-testnet.yml
+++ b/history/safe-tx-service-monad-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/monad-testnet/check/
 status: up
 code: 200
-responseTime: 309
-lastUpdated: 2026-04-12T23:10:40.011Z
+responseTime: 311
+lastUpdated: 2026-04-13T11:40:19.476Z
 startTime: 2025-11-19T09:51:43.117Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-monad.yml
+++ b/history/safe-tx-service-monad.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-monad.safe.global/check/
 status: up
 code: 200
-responseTime: 346
-lastUpdated: 2026-04-12T23:10:36.301Z
+responseTime: 336
+lastUpdated: 2026-04-13T11:40:15.969Z
 startTime: 2025-07-23T17:37:01.782Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-op-bnb.yml
+++ b/history/safe-tx-service-op-bnb.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-opbnb.safe.global/check/
 status: up
 code: 200
-responseTime: 376
-lastUpdated: 2026-04-12T23:10:36.866Z
+responseTime: 319
+lastUpdated: 2026-04-13T11:40:16.476Z
 startTime: 2025-08-27T12:42:16.466Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-optimism.yml
+++ b/history/safe-tx-service-optimism.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-optimism.safe.global/check/
 status: up
 code: 200
-responseTime: 340
-lastUpdated: 2026-04-12T23:10:24.250Z
+responseTime: 314
+lastUpdated: 2026-04-13T11:40:07.340Z
 startTime: 2022-04-27T08:51:31.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-peaq.yml
+++ b/history/safe-tx-service-peaq.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-peaq.safe.global/check/
 status: up
 code: 200
-responseTime: 324
-lastUpdated: 2026-04-12T23:10:35.144Z
+responseTime: 313
+lastUpdated: 2026-04-13T11:40:14.928Z
 startTime: 2025-06-19T11:04:40.586Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-plasma.yml
+++ b/history/safe-tx-service-plasma.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/plasma/check/
 status: up
 code: 200
-responseTime: 312
-lastUpdated: 2026-04-12T23:10:38.509Z
+responseTime: 314
+lastUpdated: 2026-04-13T11:40:17.976Z
 startTime: 2025-11-19T09:51:41.442Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-polygon-matic.yml
+++ b/history/safe-tx-service-polygon-matic.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-polygon.safe.global/check/
 status: up
 code: 200
-responseTime: 446
-lastUpdated: 2026-04-12T23:10:19.862Z
+responseTime: 299
+lastUpdated: 2026-04-13T11:40:03.705Z
 startTime: 2021-08-05T10:30:18.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-polygon-zk-evm.yml
+++ b/history/safe-tx-service-polygon-zk-evm.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-zkevm.safe.global/check/
 status: up
 code: 200
-responseTime: 507
-lastUpdated: 2026-04-12T23:10:20.569Z
+responseTime: 335
+lastUpdated: 2026-04-13T11:40:04.238Z
 startTime: 2024-03-19T10:34:26.788Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-robinhood-testnet.yml
+++ b/history/safe-tx-service-robinhood-testnet.yml
@@ -1,0 +1,7 @@
+url: https://api.safe.global/tx-service/robinhood-testnet/check/
+status: up
+code: 200
+responseTime: 314
+lastUpdated: 2026-04-13T11:40:23.974Z
+startTime: 2026-04-13T11:40:23.659Z
+generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-scroll.yml
+++ b/history/safe-tx-service-scroll.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-scroll.safe.global/check/
 status: up
 code: 200
-responseTime: 341
-lastUpdated: 2026-04-12T23:10:26.303Z
+responseTime: 337
+lastUpdated: 2026-04-13T11:40:09.389Z
 startTime: 2024-06-14T14:47:02.950Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-sepolia.yml
+++ b/history/safe-tx-service-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-sepolia.safe.global/check/
 status: up
 code: 200
-responseTime: 417
-lastUpdated: 2026-04-12T23:10:18.703Z
+responseTime: 316
+lastUpdated: 2026-04-13T11:40:01.865Z
 startTime: 2024-03-19T10:34:24.824Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-sonic.yml
+++ b/history/safe-tx-service-sonic.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-sonic.safe.global/check/
 status: up
 code: 200
-responseTime: 394
-lastUpdated: 2026-04-12T23:10:28.471Z
+responseTime: 310
+lastUpdated: 2026-04-13T11:40:11.395Z
 startTime: 2024-12-11T12:21:10.129Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-stable.yml
+++ b/history/safe-tx-service-stable.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/stable/check/
 status: up
 code: 200
-responseTime: 301
-lastUpdated: 2026-04-12T23:10:39.509Z
+responseTime: 314
+lastUpdated: 2026-04-13T11:40:18.975Z
 startTime: 2025-11-19T09:51:42.637Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-tempo-moderato.yml
+++ b/history/safe-tx-service-tempo-moderato.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/tempo-moderato/check/
 status: up
 code: 200
-responseTime: 308
-lastUpdated: 2026-04-12T23:10:43.010Z
+responseTime: 313
+lastUpdated: 2026-04-13T11:40:22.475Z
 startTime: 2026-03-13T10:03:54.843Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-tempo.yml
+++ b/history/safe-tx-service-tempo.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/tempo/check/
 status: up
 code: 200
-responseTime: 313
-lastUpdated: 2026-04-12T23:10:43.511Z
+responseTime: 312
+lastUpdated: 2026-04-13T11:40:22.974Z
 startTime: 2026-03-19T20:50:55.701Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-unichain.yml
+++ b/history/safe-tx-service-unichain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-unichain.safe.global/check/
 status: up
 code: 200
-responseTime: 337
-lastUpdated: 2026-04-12T23:10:29.518Z
+responseTime: 295
+lastUpdated: 2026-04-13T11:40:12.396Z
 startTime: 2025-02-04T11:44:48.395Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-x-layer.yml
+++ b/history/safe-tx-service-x-layer.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-xlayer.safe.global/check/
 status: up
 code: 200
-responseTime: 315
-lastUpdated: 2026-04-12T23:10:25.775Z
+responseTime: 311
+lastUpdated: 2026-04-13T11:40:08.865Z
 startTime: 2024-06-14T14:47:02.024Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-xdc.yml
+++ b/history/safe-tx-service-xdc.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-xdc.safe.global/check/
 status: up
 code: 200
-responseTime: 430
-lastUpdated: 2026-04-12T23:10:38.008Z
+responseTime: 311
+lastUpdated: 2026-04-13T11:40:17.474Z
 startTime: 2025-08-27T12:42:17.701Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-zk-sync-era-mainnet.yml
+++ b/history/safe-tx-service-zk-sync-era-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-zksync.safe.global/check/
 status: up
 code: 200
-responseTime: 313
-lastUpdated: 2026-04-12T23:10:25.275Z
+responseTime: 324
+lastUpdated: 2026-04-13T11:40:08.365Z
 startTime: 2024-03-19T10:34:31.311Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
Adds Robinhood Testnet transaction service to uptime monitoring at uptime.safe.global.
