### PR TITLE
fix: Pin GitHub Actions to full commit SHAs and disable auto-update schedule

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
-        uses: upptime/uptime-monitor@v1.41.2
+        uses: upptime/uptime-monitor@183cc1707762b9c7fa180695339d277a7840a1c8 # v1.41.2
         with:
           command: "graphs"
         env:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.2
+        uses: upptime/uptime-monitor@183cc1707762b9c7fa180695339d277a7840a1c8 # v1.41.2
         with:
           command: "response-time"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -28,41 +28,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
-        uses: upptime/uptime-monitor@v1.41.2
+        uses: upptime/uptime-monitor@183cc1707762b9c7fa180695339d277a7840a1c8 # v1.41.2
         with:
           command: "update-template"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.2
+        uses: upptime/uptime-monitor@183cc1707762b9c7fa180695339d277a7840a1c8 # v1.41.2
         with:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.2
+        uses: upptime/uptime-monitor@183cc1707762b9c7fa180695339d277a7840a1c8 # v1.41.2
         with:
           command: "readme"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1
         with:
           workflow: Graphs CI
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.2
+        uses: upptime/uptime-monitor@183cc1707762b9c7fa180695339d277a7840a1c8 # v1.41.2
         with:
           command: "site"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
-      - uses: peaceiris/actions-gh-pages@v4
+      - uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc # v4
         name: GitHub Pages Deploy
         with:
           github_token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -28,17 +28,17 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.2
+        uses: upptime/uptime-monitor@183cc1707762b9c7fa180695339d277a7840a1c8 # v1.41.2
         with:
           command: "site"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
-      - uses: peaceiris/actions-gh-pages@v4
+      - uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc # v4
         name: GitHub Pages Deploy
         with:
           github_token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.2
+        uses: upptime/uptime-monitor@183cc1707762b9c7fa180695339d277a7840a1c8 # v1.41.2
         with:
           command: "readme"
         env:

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -16,8 +16,6 @@
 
 name: Update Template CI
 on:
-  schedule:
-    - cron: "0 0 * * *"
   repository_dispatch:
     types: [update_template]
   workflow_dispatch:

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -16,8 +16,6 @@
 
 name: Updates CI
 on:
-  schedule:
-    - cron: "0 3 * * *"
   repository_dispatch:
     types: [updates]
   workflow_dispatch:

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Check endpoint status
-        uses: upptime/uptime-monitor@v1.41.2
+        uses: upptime/uptime-monitor@183cc1707762b9c7fa180695339d277a7840a1c8 # v1.41.2
         with:
           command: "update"
         env:


### PR DESCRIPTION
Org policy requires all actions to be pinned to a full-length commit SHA. Disabled the schedule on update-template.yml to prevent Upptime from regenerating workflow files and overwriting the pinned SHAs.