### PR TITLE
fix: add least-privilege permissions to Upptime workflows

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -21,6 +21,8 @@ on:
   repository_dispatch:
     types: [graphs]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Generate graphs

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -21,6 +21,8 @@ on:
   repository_dispatch:
     types: [response_time]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Check status

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -22,6 +22,8 @@ on:
   repository_dispatch:
     types: [setup]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Setup Upptime

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -21,6 +21,8 @@ on:
   repository_dispatch:
     types: [static_site]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Build and deploy site

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -21,6 +21,8 @@ on:
   repository_dispatch:
     types: [summary]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Generate README

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -21,6 +21,8 @@ on:
   repository_dispatch:
     types: [update_template]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Build

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -21,6 +21,9 @@ on:
   repository_dispatch:
     types: [updates]
   workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   release:
     name: Deploy updates

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -21,6 +21,8 @@ on:
   repository_dispatch:
     types: [uptime]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Check status


### PR DESCRIPTION
Addresses `actions/missing-workflow-permissions` warnings on all eight Upptime-generated workflows by adding least-privilege `permissions` blocks.

All eight workflows commit to the repo via `GH_PAT` (or `github.token` fallback), so they get `contents: write`. `updates.yml` additionally needs `pull-requests: write` because it opens PRs.

These files are auto-regenerated by `upptime/uptime-monitor`, so this change may be reverted on the next template run. The long-term fix would be upstream (https://github.com/upptime/upptime). Adding the blocks now clears the current alerts; if a future regeneration drops them, we'll see the alerts come back and can revisit.
