### PR TITLE
feat: Add Arc to uptime monitoring

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -99,6 +99,8 @@ sites:
     url: https://api.safe.global/tx-service/pharos/check/
   - name: Safe Tx Service (Celo Sepolia)
     url: https://api.safe.global/tx-service/celo-sepolia/check/
+  - name: Safe Tx Service (Arc)
+    url: https://api.safe.global/tx-service/arc/check/
 status-website:
   # Add your custom domain name, or remove the `cname` line if you don't have a domain
   # Uncomment the `baseUrl` line if you don't have a custom domain and add your repo name there


### PR DESCRIPTION
Adds Arc transaction service to uptime monitoring at uptime.safe.global. Production-only rollout — CLOUD-823.
