### PR TITLE
chore: add .mailmap to canonicalize author identity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Oluwapelumi Oluwaseyi <pelumi@safe.global> Oluwaseyi Oluwapelumi <oluwaseyieniayomi@gmail.com>
+Oluwapelumi Oluwaseyi <pelumi@safe.global> <oluwaseyieniayomi@gmail.com>


### PR DESCRIPTION
Adds a `.mailmap` file that remaps a stale author identity (personal Gmail with a reversed name) to the canonical work identity for the same person.

`.mailmap` only affects tools that opt into it (`git log --use-mailmap`, `git shortlog`, `git blame`, etc.). GitHub honors it on the Contributors graph but not on the per-commit page. Rewriting the commit author on master would require a force-push of every descendant commit's SHA, which is more disruptive than the cosmetic issue justifies.
