### PR TITLE
fix: pin GitHub Actions to commit SHAs (org policy)

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@cecc0f4699598de5b803d535a1b797cbc54312c8 # v1.41.7
         with:
           command: "graphs"
         env:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@cecc0f4699598de5b803d535a1b797cbc54312c8 # v1.41.7
         with:
           command: "response-time"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -30,41 +30,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@cecc0f4699598de5b803d535a1b797cbc54312c8 # v1.41.7
         with:
           command: "update-template"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@cecc0f4699598de5b803d535a1b797cbc54312c8 # v1.41.7
         with:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@cecc0f4699598de5b803d535a1b797cbc54312c8 # v1.41.7
         with:
           command: "readme"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1
         with:
           workflow: Graphs CI
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@cecc0f4699598de5b803d535a1b797cbc54312c8 # v1.41.7
         with:
           command: "site"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
-      - uses: peaceiris/actions-gh-pages@v4
+      - uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         name: GitHub Pages Deploy
         with:
           github_token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -30,17 +30,17 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@cecc0f4699598de5b803d535a1b797cbc54312c8 # v1.41.7
         with:
           command: "site"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
-      - uses: peaceiris/actions-gh-pages@v4
+      - uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         name: GitHub Pages Deploy
         with:
           github_token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@cecc0f4699598de5b803d535a1b797cbc54312c8 # v1.41.7
         with:
           command: "readme"
         env:

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
-        uses: upptime/uptime-monitor@master
+        uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # master
         with:
           command: "update-template"
         env:

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -30,11 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update code
-        uses: upptime/updates@master
+        uses: upptime/updates@c8be3a2281e37dfb3211b7cd8f847b014e551634 # master
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Check endpoint status
-        uses: upptime/uptime-monitor@v1.41.7
+        uses: upptime/uptime-monitor@cecc0f4699598de5b803d535a1b797cbc54312c8 # v1.41.7
         with:
           command: "update"
         env:


### PR DESCRIPTION
## Problem
The `safe-global` org enforces **all Actions must be pinned to a full-length commit SHA**. Every workflow referenced actions by tag/branch, so since ~2026-05-27 00:58 UTC **all scheduled runs fail at "Set up job"** — uptime monitoring, graphs, summary, response-time and the static site are all down.

```
##[error] The actions actions/checkout@v5 and upptime/uptime-monitor@v1.41.7 are not allowed
in safe-global/safe-services-status because all actions must be pinned to a full-length commit SHA.
```

## Fix
Pin every action to its resolved commit SHA, original tag kept as a trailing comment:

| Action | Pinned SHA (tag) |
|---|---|
| actions/checkout | `93cb6efe…bf9bfd` (v5) |
| upptime/uptime-monitor | `cecc0f46…4312c8` (v1.41.7), `30868e46…7453c7` (master) |
| upptime/updates | `c8be3a22…551634` (master) |
| benc-uk/workflow-dispatch | `31e2b331…504e26` (v1) |
| peaceiris/actions-gh-pages | `4f9cc660…f4d45e` (v4) |

## Follow-up
Workflows are template-generated and use tags upstream, so **Update Template CI** would re-introduce unpinned tags. Recommend disabling that workflow (or it will re-break CI on the next template sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)