### PR TITLE
feat: add per-service chain icons (kills DDG favicon 404s)

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9
         with:
           command: "graphs"
         env:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9
         with:
           command: "response-time"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -32,12 +32,11 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
-      - name: Update template
-        uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9
-        with:
-          command: "update-template"
-        env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
+      # NOTE: "Update template" step removed on purpose.
+      # It regenerates every workflow from the upstream Upptime template, which uses
+      # unpinned tag refs (@v5, @v1.41.x, @master, ...). The safe-global org policy
+      # rejects unpinned actions, so each regeneration breaks all CI. See #18228, this PR.
+      # Workflows are now hand-pinned to commit SHAs; bump them deliberately when needed.
       - name: Update response time
         uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9
         with:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -28,41 +28,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9
         with:
           command: "update-template"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9
         with:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9
         with:
           command: "readme"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1
         with:
           workflow: Graphs CI
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9
         with:
           command: "site"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
-      - uses: peaceiris/actions-gh-pages@v4
+      - uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         name: GitHub Pages Deploy
         with:
           github_token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -28,17 +28,17 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9
         with:
           command: "site"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
-      - uses: peaceiris/actions-gh-pages@v4
+      - uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         name: GitHub Pages Deploy
         with:
           github_token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9
         with:
           command: "readme"
         env:

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
-        uses: upptime/uptime-monitor@master
+        uses: upptime/uptime-monitor@881c09b0963714dce74cdd7ac35534e9b13dc21c # master
         with:
           command: "update-template"
         env:

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -27,11 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update code
-        uses: upptime/updates@master
+        uses: upptime/updates@c8be3a2281e37dfb3211b7cd8f847b014e551634 # master
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Check endpoint status
-        uses: upptime/uptime-monitor@v1.41.9
+        uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9
         with:
           command: "update"
         env:

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -5,106 +5,157 @@ skipTopicsUpdate: true
 sites:
   - name: Safe Client Gateway
     url: https://safe-client.safe.global/health/ready/
+    icon: https://app.safe.global/favicon.ico
   - name: Safe Tx Service (Mainnet)
     url: https://safe-transaction-mainnet.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/1/chain_logo.png
   - name: Safe Tx Service (Gnosis Chain)
     url: https://safe-transaction-gnosis-chain.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/100/chain_logo.png
   - name: Safe Tx Service (Sepolia)
     url: https://safe-transaction-sepolia.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/11155111/chain_logo.png
   - name: Safe Tx Service (Binance Smart Chain)
     url: https://safe-transaction-bsc.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/56/chain_logo.png
   - name: Safe Tx Service (Polygon - Matic)
     url: https://safe-transaction-polygon.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/137/chain_logo.png
   - name: Safe Tx Service (Polygon - zkEVM)
     url: https://safe-transaction-zkevm.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/1101/chain_logo.png
   - name: Safe Tx Service (Base Mainnet)
     url: https://safe-transaction-base.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/8453/chain_logo.png
   - name: Safe Tx Service (Base Sepolia)
     url: https://safe-transaction-base-sepolia.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/84532/chain_logo.png
   - name: Safe Tx Service (Celo)
     url: https://safe-transaction-celo.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/42220/chain_logo.png
   - name: Safe Tx Service (Arbitrum)
     url: https://safe-transaction-arbitrum.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/42161/chain_logo.png
   - name: Safe Tx Service (Avalanche)
     url: https://safe-transaction-avalanche.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/43114/chain_logo.png
   - name: Safe Tx Service (Optimism)
     url: https://safe-transaction-optimism.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/10/chain_logo.png
   - name: Safe Tx Service (Aurora)
     url: https://safe-transaction-aurora.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/1313161554/chain_logo.png
   - name: Safe Tx Service (zkSync Era Mainnet)
     url: https://safe-transaction-zksync.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/324/chain_logo.png
   - name: Safe Tx Service (xLayer)
     url: https://safe-transaction-xlayer.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/196/chain_logo.png
   - name: Safe Tx Service (Scroll)
     url: https://safe-transaction-scroll.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/534352/chain_logo.png
   - name: Safe Tx Service (Linea)
     url: https://safe-transaction-linea.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/59144/chain_logo.png
   - name: Safe Tx Service (Chiado)
     url: https://safe-transaction-chiado.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/10200/chain_logo.png
   - name: Safe Tx Service (Mantle)
     url: https://safe-transaction-mantle.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/5000/chain_logo.png
   - name: Safe Tx Service (Sonic)
     url: https://safe-transaction-sonic.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/146/chain_logo.png
   - name: Safe Tx Service (Ink)
     url: https://safe-transaction-ink.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/57073/chain_logo.png
   - name: Safe Tx Service (Unichain)
     url: https://safe-transaction-unichain.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/130/chain_logo.png
   - name: Safe Tx Service (Berachain)
     url: https://safe-transaction-berachain.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/80094/chain_logo.png
   - name: Safe Tx Service (Lens)
     url: https://safe-transaction-lens.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/232/chain_logo.png
   - name: Safe Tx Service (Hemi)
     url: https://safe-transaction-hemi.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/43111/chain_logo.png
   - name: Safe Tx Service (Katana)
     url: https://safe-transaction-katana.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/747474/chain_logo.png
   - name: Safe Tx Service (Peaq)
     url: https://safe-transaction-peaq.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/3338/chain_logo.png
   - name: Safe Tx Service (Codex)
     url: https://safe-transaction-codex.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/81224/chain_logo.png
   - name: Safe Tx Service (Monad)
     url: https://safe-transaction-monad.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/143/chain_logo.png
   - name: Safe Tx Service (OpBNB)
     url: https://safe-transaction-opbnb.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/204/chain_logo.png
   - name: Safe Tx Service (Botanix)
     url: https://safe-transaction-botanix.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/3637/chain_logo.png
   - name: Safe Tx Service (XDC)
     url: https://safe-transaction-xdc.safe.global/check/
+    icon: https://safe-transaction-assets.safe.global/chains/50/chain_logo.png
   - name: Safe Tx Service (Plasma)
     url: https://api.safe.global/tx-service/plasma/check/
+    icon: https://safe-transaction-assets.safe.global/chains/9745/chain_logo.png
   - name: Safe Tx Service (0g)
     url: https://api.safe.global/tx-service/0g/check/
+    icon: https://safe-transaction-assets.safe.global/chains/16661/chain_logo.png
   - name: Safe Tx Service (Stable)
     url: https://api.safe.global/tx-service/stable/check/
+    icon: https://safe-transaction-assets.safe.global/chains/988/chain_logo.png
   - name: Safe Tx Service (Monad Testnet)
     url: https://api.safe.global/tx-service/monad-testnet/check/
+    icon: https://safe-transaction-assets.safe.global/chains/10143/chain_logo.png
   - name: Safe Tx Service (HyperEvm)
     url: https://api.safe.global/tx-service/hyper/check/
+    icon: https://safe-transaction-assets.safe.global/chains/999/chain_logo.png
   - name: Safe Tx Service (MegaEth)
     url: https://api.safe.global/tx-service/mega/check/
+    icon: https://safe-transaction-assets.safe.global/chains/4326/chain_logo.png
   - name: Safe Tx Service (Arc Testnet)
     url: https://api.safe.global/tx-service/arc-testnet/check/
+    icon: https://safe-transaction-assets.safe.global/chains/5042002/chain_logo.png
   - name: Safe Tx Service (Creditcoin)
     url: https://api.safe.global/tx-service/ctc/check/
+    icon: https://safe-transaction-assets.safe.global/chains/102030/chain_logo.png
   - name: Safe Tx Service (Mantle Sepolia)
     url: https://api.safe.global/tx-service/mnt-sep/check/
+    icon: https://safe-transaction-assets.safe.global/chains/5003/chain_logo.png
   - name: Safe Tx Service (Tempo Moderato)
     url: https://api.safe.global/tx-service/tempo-moderato/check/
+    icon: https://safe-transaction-assets.safe.global/chains/42431/chain_logo.png
   - name: Safe Tx Service (Tempo)
     url: https://api.safe.global/tx-service/tempo/check/
+    icon: https://safe-transaction-assets.safe.global/chains/4217/chain_logo.png
   - name: Safe Tx Service (Fluent)
     url: https://api.safe.global/tx-service/fluent/check/
+    icon: https://safe-transaction-assets.safe.global/chains/25363/chain_logo.png
   - name: Safe Tx Service (Robinhood Testnet)
     url: https://api.safe.global/tx-service/robinhood-testnet/check/
+    icon: https://safe-transaction-assets.safe.global/chains/46630/chain_logo.png
   - name: Safe Tx Service (Pharos)
     url: https://api.safe.global/tx-service/pharos/check/
+    icon: https://safe-transaction-assets.safe.global/chains/1672/chain_logo.png
   - name: Safe Tx Service (Celo  Sepolia)
     url: https://api.safe.global/tx-service/celo-sep/check/
+    icon: https://safe-transaction-assets.safe.global/chains/11142220/chain_logo.png
   - name: Safe Tx Service (Arc)
     url: https://api.safe.global/tx-service/arc/check/
+    icon: https://safe-transaction-assets.safe.global/chains/5042/chain_logo.png
   - name: Safe Tx Service (Aetherium)
     url: https://api.safe.global/tx-service/aeth/check/
+    icon: https://safe-transaction-assets.safe.global/chains/4663/chain_logo.png
   - name: Safe Tx Service (Kairos)
     url: https://api.safe.global/tx-service/kairos/check/
+    icon: https://icons.llamao.fi/icons/chains/rsz_kaia.jpg
 status-website:
   # Add your custom domain name, or remove the `cname` line if you don't have a domain
   # Uncomment the `baseUrl` line if you don't have a custom domain and add your repo name there

--- a/history/safe-client-gateway.yml
+++ b/history/safe-client-gateway.yml
@@ -1,7 +1,7 @@
 url: https://safe-client.safe.global/health/ready/
 status: up
 code: 200
-responseTime: 193
-lastUpdated: 2026-05-28T09:18:27.017Z
+responseTime: 355
+lastUpdated: 2026-05-29T09:52:54.533Z
 startTime: 2024-06-14T14:46:50.293Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-0g.yml
+++ b/history/safe-tx-service-0g.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/0g/check/
 status: up
 code: 200
-responseTime: 477
-lastUpdated: 2026-05-28T09:18:44.090Z
+responseTime: 467
+lastUpdated: 2026-05-29T09:53:13.069Z
 startTime: 2025-11-19T09:51:42.016Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-aetherium.yml
+++ b/history/safe-tx-service-aetherium.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/aeth/check/
 status: up
 code: 200
-responseTime: 471
-lastUpdated: 2026-05-28T09:18:51.586Z
+responseTime: 470
+lastUpdated: 2026-05-29T09:53:20.572Z
 startTime: 2026-05-26T08:27:19.516Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arbitrum.yml
+++ b/history/safe-tx-service-arbitrum.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-arbitrum.safe.global/check/
 status: up
 code: 200
-responseTime: 472
-lastUpdated: 2026-05-28T09:18:32.022Z
+responseTime: 468
+lastUpdated: 2026-05-29T09:53:00.369Z
 startTime: 2021-08-05T10:30:22.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arc-testnet.yml
+++ b/history/safe-tx-service-arc-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/arc-testnet/check/
 status: up
 code: 200
-responseTime: 477
-lastUpdated: 2026-05-28T09:18:46.591Z
+responseTime: 467
+lastUpdated: 2026-05-29T09:53:15.568Z
 startTime: 2026-01-16T19:30:22.108Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arc.yml
+++ b/history/safe-tx-service-arc.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/arc/check/
 status: up
 code: 200
-responseTime: 474
-lastUpdated: 2026-05-28T09:18:51.091Z
+responseTime: 467
+lastUpdated: 2026-05-29T09:53:20.069Z
 startTime: 2026-05-22T09:34:40.849Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-aurora.yml
+++ b/history/safe-tx-service-aurora.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-aurora.safe.global/check/
 status: up
 code: 200
-responseTime: 474
-lastUpdated: 2026-05-28T09:18:33.524Z
+responseTime: 497
+lastUpdated: 2026-05-29T09:53:02.137Z
 startTime: 2024-03-19T10:34:30.573Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-avalanche.yml
+++ b/history/safe-tx-service-avalanche.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-avalanche.safe.global/check/
 status: up
 code: 200
-responseTime: 477
-lastUpdated: 2026-05-28T09:18:32.524Z
+responseTime: 469
+lastUpdated: 2026-05-29T09:53:00.869Z
 startTime: 2022-03-25T11:57:26.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-base-mainnet.yml
+++ b/history/safe-tx-service-base-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-base.safe.global/check/
 status: up
 code: 200
-responseTime: 473
-lastUpdated: 2026-05-28T09:18:30.528Z
+responseTime: 489
+lastUpdated: 2026-05-29T09:52:58.663Z
 startTime: 2024-06-14T14:46:55.924Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-base-sepolia.yml
+++ b/history/safe-tx-service-base-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-base-sepolia.safe.global/check/
 status: up
 code: 200
-responseTime: 471
-lastUpdated: 2026-05-28T09:18:31.024Z
+responseTime: 490
+lastUpdated: 2026-05-29T09:52:59.190Z
 startTime: 2024-03-19T10:34:27.349Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-berachain.yml
+++ b/history/safe-tx-service-berachain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-berachain.safe.global/check/
 status: up
 code: 200
-responseTime: 543
-lastUpdated: 2026-05-28T09:18:38.592Z
+responseTime: 505
+lastUpdated: 2026-05-29T09:53:07.381Z
 startTime: 2025-02-17T09:20:55.646Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-binance-smart-chain.yml
+++ b/history/safe-tx-service-binance-smart-chain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-bsc.safe.global/check/
 status: up
 code: 200
-responseTime: 479
-lastUpdated: 2026-05-28T09:18:28.970Z
+responseTime: 493
+lastUpdated: 2026-05-29T09:52:56.892Z
 startTime: 2021-08-05T10:30:17.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-botanix.yml
+++ b/history/safe-tx-service-botanix.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-botanix.safe.global/check/
 status: up
 code: 200
-responseTime: 472
-lastUpdated: 2026-05-28T09:18:42.589Z
+responseTime: 489
+lastUpdated: 2026-05-29T09:53:11.543Z
 startTime: 2025-08-27T12:42:17.067Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-celo-sepolia.yml
+++ b/history/safe-tx-service-celo-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/celo-sep/check/
 status: up
 code: 200
-responseTime: 478
-lastUpdated: 2026-05-28T09:18:50.591Z
+responseTime: 468
+lastUpdated: 2026-05-29T09:53:19.571Z
 startTime: 2026-04-28T07:36:23.579Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-celo.yml
+++ b/history/safe-tx-service-celo.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-celo.safe.global/check/
 status: up
 code: 200
-responseTime: 476
-lastUpdated: 2026-05-28T09:18:31.525Z
+responseTime: 545
+lastUpdated: 2026-05-29T09:52:59.869Z
 startTime: 2023-05-23T15:39:32.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-chiado.yml
+++ b/history/safe-tx-service-chiado.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-chiado.safe.global/check/
 status: up
 code: 200
-responseTime: 476
-lastUpdated: 2026-05-28T09:18:36.023Z
+responseTime: 544
+lastUpdated: 2026-05-29T09:53:04.801Z
 startTime: 2024-08-16T10:52:40.346Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-codex.yml
+++ b/history/safe-tx-service-codex.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-codex.safe.global/check/
 status: up
 code: 200
-responseTime: 477
-lastUpdated: 2026-05-28T09:18:41.094Z
+responseTime: 520
+lastUpdated: 2026-05-29T09:53:09.988Z
 startTime: 2025-07-15T12:51:17.948Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-creditcoin.yml
+++ b/history/safe-tx-service-creditcoin.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/ctc/check/
 status: up
 code: 200
-responseTime: 474
-lastUpdated: 2026-05-28T09:18:47.091Z
+responseTime: 471
+lastUpdated: 2026-05-29T09:53:16.070Z
 startTime: 2026-03-06T09:26:54.038Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-fluent.yml
+++ b/history/safe-tx-service-fluent.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/fluent/check/
 status: up
 code: 200
-responseTime: 471
-lastUpdated: 2026-05-28T09:18:49.088Z
+responseTime: 469
+lastUpdated: 2026-05-29T09:53:18.068Z
 startTime: 2026-04-08T07:35:21.962Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-gnosis-chain.yml
+++ b/history/safe-tx-service-gnosis-chain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-gnosis-chain.safe.global/check/
 status: up
 code: 200
-responseTime: 476
-lastUpdated: 2026-05-28T09:18:27.967Z
+responseTime: 468
+lastUpdated: 2026-05-29T09:52:55.861Z
 startTime: 2022-12-21T17:20:44.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-hemi.yml
+++ b/history/safe-tx-service-hemi.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-hemi.safe.global/check/
 status: up
 code: 200
-responseTime: 472
-lastUpdated: 2026-05-28T09:18:39.588Z
+responseTime: 509
+lastUpdated: 2026-05-29T09:53:08.422Z
 startTime: 2025-04-29T10:31:54.263Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-hyper-evm.yml
+++ b/history/safe-tx-service-hyper-evm.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/hyper/check/
 status: up
 code: 200
-responseTime: 476
-lastUpdated: 2026-05-28T09:18:45.592Z
+responseTime: 469
+lastUpdated: 2026-05-29T09:53:14.571Z
 startTime: 2025-11-19T09:51:43.815Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-ink.yml
+++ b/history/safe-tx-service-ink.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-ink.safe.global/check/
 status: up
 code: 200
-responseTime: 479
-lastUpdated: 2026-05-28T09:18:37.526Z
+responseTime: 492
+lastUpdated: 2026-05-29T09:53:06.357Z
 startTime: 2024-12-12T17:15:05.125Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-kairos.yml
+++ b/history/safe-tx-service-kairos.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/kairos/check/
-status: down
-code: 404
-responseTime: 147
-lastUpdated: 2026-05-28T09:19:04.093Z
+status: up
+code: 200
+responseTime: 465
+lastUpdated: 2026-05-29T09:53:21.069Z
 startTime: 2026-05-28T09:18:51.609Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-katana.yml
+++ b/history/safe-tx-service-katana.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-katana.safe.global/check/
 status: up
 code: 200
-responseTime: 476
-lastUpdated: 2026-05-28T09:18:40.089Z
+responseTime: 472
+lastUpdated: 2026-05-29T09:53:08.925Z
 startTime: 2025-06-12T12:51:37.947Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-lens.yml
+++ b/history/safe-tx-service-lens.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-lens.safe.global/check/
 status: up
 code: 200
-responseTime: 473
-lastUpdated: 2026-05-28T09:18:39.090Z
+responseTime: 470
+lastUpdated: 2026-05-29T09:53:07.882Z
 startTime: 2025-04-29T10:31:53.750Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-linea.yml
+++ b/history/safe-tx-service-linea.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-linea.safe.global/check/
 status: up
 code: 200
-responseTime: 474
-lastUpdated: 2026-05-28T09:18:35.523Z
+responseTime: 504
+lastUpdated: 2026-05-29T09:53:04.225Z
 startTime: 2024-08-13T14:27:58.910Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mainnet.yml
+++ b/history/safe-tx-service-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-mainnet.safe.global/check/
 status: up
 code: 200
-responseTime: 423
-lastUpdated: 2026-05-28T09:18:27.466Z
+responseTime: 762
+lastUpdated: 2026-05-29T09:52:55.362Z
 startTime: 2021-08-05T10:30:13.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mantle-sepolia.yml
+++ b/history/safe-tx-service-mantle-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/mnt-sep/check/
 status: up
 code: 200
-responseTime: 473
-lastUpdated: 2026-05-28T09:18:47.590Z
+responseTime: 467
+lastUpdated: 2026-05-29T09:53:16.569Z
 startTime: 2026-03-09T14:14:37.684Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mantle.yml
+++ b/history/safe-tx-service-mantle.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-mantle.safe.global/check/
 status: up
 code: 200
-responseTime: 474
-lastUpdated: 2026-05-28T09:18:36.523Z
+responseTime: 491
+lastUpdated: 2026-05-29T09:53:05.324Z
 startTime: 2024-09-23T12:22:22.690Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mega-eth.yml
+++ b/history/safe-tx-service-mega-eth.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/mega/check/
 status: up
 code: 200
-responseTime: 471
-lastUpdated: 2026-05-28T09:18:46.090Z
+responseTime: 466
+lastUpdated: 2026-05-29T09:53:15.069Z
 startTime: 2025-11-19T09:51:44.285Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-monad-testnet.yml
+++ b/history/safe-tx-service-monad-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/monad-testnet/check/
 status: up
 code: 200
-responseTime: 474
-lastUpdated: 2026-05-28T09:18:45.091Z
+responseTime: 467
+lastUpdated: 2026-05-29T09:53:14.069Z
 startTime: 2025-11-19T09:51:43.117Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-monad.yml
+++ b/history/safe-tx-service-monad.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-monad.safe.global/check/
 status: up
 code: 200
-responseTime: 472
-lastUpdated: 2026-05-28T09:18:41.591Z
+responseTime: 483
+lastUpdated: 2026-05-29T09:53:10.502Z
 startTime: 2025-07-23T17:37:01.782Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-op-bnb.yml
+++ b/history/safe-tx-service-op-bnb.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-opbnb.safe.global/check/
 status: up
 code: 200
-responseTime: 477
-lastUpdated: 2026-05-28T09:18:42.093Z
+responseTime: 489
+lastUpdated: 2026-05-29T09:53:11.023Z
 startTime: 2025-08-27T12:42:16.466Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-optimism.yml
+++ b/history/safe-tx-service-optimism.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-optimism.safe.global/check/
 status: up
 code: 200
-responseTime: 477
-lastUpdated: 2026-05-28T09:18:33.026Z
+responseTime: 707
+lastUpdated: 2026-05-29T09:53:01.608Z
 startTime: 2022-04-27T08:51:31.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-peaq.yml
+++ b/history/safe-tx-service-peaq.yml
@@ -2,6 +2,6 @@ url: https://safe-transaction-peaq.safe.global/check/
 status: up
 code: 200
 responseTime: 478
-lastUpdated: 2026-05-28T09:18:40.592Z
+lastUpdated: 2026-05-29T09:53:09.435Z
 startTime: 2025-06-19T11:04:40.586Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-pharos.yml
+++ b/history/safe-tx-service-pharos.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/pharos/check/
 status: up
 code: 200
-responseTime: 474
-lastUpdated: 2026-05-28T09:18:50.089Z
+responseTime: 470
+lastUpdated: 2026-05-29T09:53:19.071Z
 startTime: 2026-04-24T10:19:44.208Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-plasma.yml
+++ b/history/safe-tx-service-plasma.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/plasma/check/
 status: up
 code: 200
-responseTime: 476
-lastUpdated: 2026-05-28T09:18:43.588Z
+responseTime: 469
+lastUpdated: 2026-05-29T09:53:12.569Z
 startTime: 2025-11-19T09:51:41.442Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-polygon-matic.yml
+++ b/history/safe-tx-service-polygon-matic.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-polygon.safe.global/check/
 status: up
 code: 200
-responseTime: 470
-lastUpdated: 2026-05-28T09:18:29.473Z
+responseTime: 631
+lastUpdated: 2026-05-29T09:52:57.554Z
 startTime: 2021-08-05T10:30:18.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-polygon-zk-evm.yml
+++ b/history/safe-tx-service-polygon-zk-evm.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-zkevm.safe.global/check/
 status: up
 code: 200
-responseTime: 529
-lastUpdated: 2026-05-28T09:18:30.026Z
+responseTime: 557
+lastUpdated: 2026-05-29T09:52:58.143Z
 startTime: 2024-03-19T10:34:26.788Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-robinhood-testnet.yml
+++ b/history/safe-tx-service-robinhood-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/robinhood-testnet/check/
 status: up
 code: 200
-responseTime: 478
-lastUpdated: 2026-05-28T09:18:49.590Z
+responseTime: 469
+lastUpdated: 2026-05-29T09:53:18.569Z
 startTime: 2026-04-13T11:40:23.659Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-scroll.yml
+++ b/history/safe-tx-service-scroll.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-scroll.safe.global/check/
 status: up
 code: 200
-responseTime: 477
-lastUpdated: 2026-05-28T09:18:35.024Z
+responseTime: 502
+lastUpdated: 2026-05-29T09:53:03.690Z
 startTime: 2024-06-14T14:47:02.950Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-sepolia.yml
+++ b/history/safe-tx-service-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-sepolia.safe.global/check/
 status: up
 code: 200
-responseTime: 475
-lastUpdated: 2026-05-28T09:18:28.466Z
+responseTime: 474
+lastUpdated: 2026-05-29T09:52:56.367Z
 startTime: 2024-03-19T10:34:24.824Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-sonic.yml
+++ b/history/safe-tx-service-sonic.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-sonic.safe.global/check/
 status: up
 code: 200
-responseTime: 476
-lastUpdated: 2026-05-28T09:18:37.022Z
+responseTime: 477
+lastUpdated: 2026-05-29T09:53:05.833Z
 startTime: 2024-12-11T12:21:10.129Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-stable.yml
+++ b/history/safe-tx-service-stable.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/stable/check/
 status: up
 code: 200
-responseTime: 477
-lastUpdated: 2026-05-28T09:18:44.592Z
+responseTime: 468
+lastUpdated: 2026-05-29T09:53:13.570Z
 startTime: 2025-11-19T09:51:42.637Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-tempo-moderato.yml
+++ b/history/safe-tx-service-tempo-moderato.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/tempo-moderato/check/
 status: up
 code: 200
-responseTime: 477
-lastUpdated: 2026-05-28T09:18:48.092Z
+responseTime: 469
+lastUpdated: 2026-05-29T09:53:17.070Z
 startTime: 2026-03-13T10:03:54.843Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-tempo.yml
+++ b/history/safe-tx-service-tempo.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/tempo/check/
 status: up
 code: 200
-responseTime: 476
-lastUpdated: 2026-05-28T09:18:48.592Z
+responseTime: 466
+lastUpdated: 2026-05-29T09:53:17.568Z
 startTime: 2026-03-19T20:50:55.701Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-unichain.yml
+++ b/history/safe-tx-service-unichain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-unichain.safe.global/check/
 status: up
 code: 200
-responseTime: 474
-lastUpdated: 2026-05-28T09:18:38.024Z
+responseTime: 455
+lastUpdated: 2026-05-29T09:53:06.845Z
 startTime: 2025-02-04T11:44:48.395Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-x-layer.yml
+++ b/history/safe-tx-service-x-layer.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-xlayer.safe.global/check/
 status: up
 code: 200
-responseTime: 474
-lastUpdated: 2026-05-28T09:18:34.522Z
+responseTime: 490
+lastUpdated: 2026-05-29T09:53:03.156Z
 startTime: 2024-06-14T14:47:02.024Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-xdc.yml
+++ b/history/safe-tx-service-xdc.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-xdc.safe.global/check/
 status: up
 code: 200
-responseTime: 473
-lastUpdated: 2026-05-28T09:18:43.087Z
+responseTime: 493
+lastUpdated: 2026-05-29T09:53:12.068Z
 startTime: 2025-08-27T12:42:17.701Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-zk-sync-era-mainnet.yml
+++ b/history/safe-tx-service-zk-sync-era-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-zksync.safe.global/check/
 status: up
 code: 200
-responseTime: 474
-lastUpdated: 2026-05-28T09:18:34.023Z
+responseTime: 467
+lastUpdated: 2026-05-29T09:53:02.635Z
 startTime: 2024-03-19T10:34:31.311Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
## Three changes (one feature + two infra fixes that unblock the feature)

### 1. Add per-service chain icons (`.upptimerc.yml`, +51 lines)
The status page renders each service's favicon via the upstream default:
```js
fallbackIcon = `https://icons.duckduckgo.com/ip3/${parse(site.url).hostname}.ico`
```
Every Safe monitored host is an API subdomain (`safe-client.safe.global`, `safe-transaction-*.safe.global`, `api.safe.global`), and DuckDuckGo has no favicon for any of them → all 51 favicon requests 404 in the browser.

Upptime supports a per-site `icon:` field that overrides the DDG fallback (`uptime-monitor/src/summary.ts` `L51-59`: `icon: site.icon || fallbackIcon`). One added under each `url:`.

**Source per site**

| Group | Count | URL pattern |
|---|---|---|
| Chain logos from Safe's own CDN (keyed by chainId from `safe-config.safe.global/api/v1/chains/`) | 50 | `https://safe-transaction-assets.safe.global/chains/<chainId>/chain_logo.png` |
| Safe Client Gateway | 1 | `https://app.safe.global/favicon.ico` |
| Kairos (Kaia testnet — not yet in Safe's chain config) | 1 | `https://icons.llamao.fi/icons/chains/rsz_kaia.jpg` |

All 51 URLs probed and return `200 image/*` before opening this PR.

### 2. Re-pin all workflow actions to commit SHAs
`#18231` (Add Kairos) regenerated all workflows from the upstream Upptime template, which uses unpinned tag refs (`@v5`, `@v1.41.9`, `@master`, …). The `safe-global` org policy rejects unpinned actions, so the first Setup CI run on this PR died at *Set up job* with:
```
The actions actions/checkout@v5, upptime/uptime-monitor@v1.41.9, benc-uk/workflow-dispatch@v1, and peaceiris/actions-gh-pages@v4 are not allowed ... because all actions must be pinned to a full-length commit SHA.
```
Re-applies the SHA-pin pattern from `#18228` (and `#18218`/`#18221` before that) to the newer template versions: commit SHA pinned, original tag kept in a trailing comment.

### 3. Remove the "Update template" step from Setup CI
This is the **structural fix that breaks the regression loop**. The step runs `upptime/uptime-monitor` with `command: update-template`, which **regenerates every workflow file** from the upstream Upptime template (always with unpinned tag refs). Every push that touches `.upptimerc.yml` was therefore un-pinning the workflows again — see `#18218 / #18221 / #18228` for the same fight in the past.

With this step gone, the rest of Setup CI still works (response-time, README, graphs, site, gh-pages deploy), and the team bumps Upptime by editing workflow files and pins deliberately. Update Template CI remains disabled (from `#18228`).

## Verifying

The historic *Set up job* failure on the first commit (`3fc1d05465`) is frozen — it was triggered before the pinning fix landed in this branch and can't be retroactively un-failed. A fresh Setup CI dispatched against the latest commit is running to confirm the chain works end-to-end on the new head.

## After merge

1. **Summary CI** → bakes `icon` fields into `history/summary.json`.
2. **Static Site CI** → redeploys; per-chain logos appear on `uptime.safe.global` and in the README table.
3. Browser network tab: every favicon → 200 from Safe's CDN; no more DDG 404s.

## Maintenance

When adding a new chain to monitor, also add an `icon:` line — pull the URL from `https://safe-config.safe.global/api/v1/chains/` by chainId. If Safe's chain config doesn't have it yet (like Kairos today), fall back to DefiLlama (`https://icons.llamao.fi/icons/chains/rsz_<key>.jpg`) and swap once it's added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)