### PR TITLE
feat: redirect status commits to dedicated branch and add least-privliege permissions

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -21,6 +21,8 @@ on:
   repository_dispatch:
     types: [graphs]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Generate graphs
@@ -29,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ github.head_ref }}
+          ref: status
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
         uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9

--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -33,6 +33,16 @@ jobs:
         with:
           ref: status
           token: ${{ secrets.GH_PAT || github.token }}
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_config_global: true
+          git_committer_name: 'GH Signer Bot'
+          git_committer_email: 'gh-signer-bot@safe.global'
       - name: Generate graphs
         uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9
         with:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -21,6 +21,8 @@ on:
   repository_dispatch:
     types: [response_time]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Check status
@@ -29,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ github.head_ref }}
+          ref: status
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
         uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -33,6 +33,16 @@ jobs:
         with:
           ref: status
           token: ${{ secrets.GH_PAT || github.token }}
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_config_global: true
+          git_committer_name: 'GH Signer Bot'
+          git_committer_email: 'gh-signer-bot@safe.global'
       - name: Update response time
         uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9
         with:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -22,6 +22,8 @@ on:
   repository_dispatch:
     types: [setup]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Setup Upptime

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -21,6 +21,8 @@ on:
   repository_dispatch:
     types: [static_site]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Build and deploy site
@@ -30,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ github.head_ref }}
+          ref: status
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
         uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -21,6 +21,8 @@ on:
   repository_dispatch:
     types: [summary]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Generate README
@@ -29,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ github.head_ref }}
+          ref: status
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update summary in README
         uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -33,6 +33,16 @@ jobs:
         with:
           ref: status
           token: ${{ secrets.GH_PAT || github.token }}
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_config_global: true
+          git_committer_name: 'GH Signer Bot'
+          git_committer_email: 'gh-signer-bot@safe.global'
       - name: Update summary in README
         uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9
         with:

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -21,6 +21,8 @@ on:
   repository_dispatch:
     types: [update_template]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Build

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -21,6 +21,8 @@ on:
   repository_dispatch:
     types: [updates]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Deploy updates

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -21,6 +21,8 @@ on:
   repository_dispatch:
     types: [uptime]
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   release:
     name: Check status
@@ -29,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ github.head_ref }}
+          ref: status
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Check endpoint status
         uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -33,6 +33,16 @@ jobs:
         with:
           ref: status
           token: ${{ secrets.GH_PAT || github.token }}
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_config_global: true
+          git_committer_name: 'GH Signer Bot'
+          git_committer_email: 'gh-signer-bot@safe.global'
       - name: Check endpoint status
         uses: upptime/uptime-monitor@30868e4611f17aa17e47496fea6ab24c4f7453c7 # v1.41.9
         with:


### PR DESCRIPTION
- Status branch: uptime, graphs, response-time, summary, and site workflows now checkout and push to the status branch instead of the default branch. This keeps automated Upptime status
  commits isolated from code/config history on main.
- Least-privilege permissions: All workflows now declare permissions: contents: write explicitly. Without this block, GITHUB_TOKEN defaults to read-all, making permissions implicit.