### PR TITLE
feat: Add whitechain-sepolia uptime monitoring

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -162,6 +162,9 @@ sites:
   - name: Safe Tx Service (Botchain)
     url: https://api.safe.global/tx-service/bot/check/
     icon: https://safe-transaction-assets.safe.global/chains/677/chain_logo.png
+  - name: Safe Tx Service (Whitechain Sepolia)
+    url: https://api.safe.global/tx-service/wch-sepolia/check/
+    icon: https://safe-transaction-assets.safe.global/chains/1874/chain_logo.png
 status-website:
   # Add your custom domain name, or remove the `cname` line if you don't have a domain
   # Uncomment the `baseUrl` line if you don't have a custom domain and add your repo name there

--- a/history/safe-client-gateway.yml
+++ b/history/safe-client-gateway.yml
@@ -1,7 +1,7 @@
 url: https://safe-client.safe.global/health/ready/
 status: up
 code: 200
-responseTime: 372
-lastUpdated: 2026-07-14T23:40:13.564Z
+responseTime: 341
+lastUpdated: 2026-07-15T09:14:26.692Z
 startTime: 2024-06-14T14:46:50.293Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-0g.yml
+++ b/history/safe-tx-service-0g.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/0g/check/
 status: up
 code: 200
-responseTime: 476
-lastUpdated: 2026-07-14T23:40:33.876Z
+responseTime: 506
+lastUpdated: 2026-07-15T09:14:43.980Z
 startTime: 2025-11-19T09:51:42.016Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-aetherium.yml
+++ b/history/safe-tx-service-aetherium.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/aeth/check/
 status: up
 code: 200
-responseTime: 471
-lastUpdated: 2026-07-14T23:40:41.377Z
+responseTime: 467
+lastUpdated: 2026-07-15T09:14:51.440Z
 startTime: 2026-05-26T08:27:19.516Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arbitrum.yml
+++ b/history/safe-tx-service-arbitrum.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-arbitrum.safe.global/check/
 status: up
 code: 200
-responseTime: 461
-lastUpdated: 2026-07-14T23:40:20.019Z
+responseTime: 466
+lastUpdated: 2026-07-15T09:14:31.881Z
 startTime: 2021-08-05T10:30:22.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arc-testnet.yml
+++ b/history/safe-tx-service-arc-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/arc-testnet/check/
 status: up
 code: 200
-responseTime: 470
-lastUpdated: 2026-07-14T23:40:36.377Z
+responseTime: 462
+lastUpdated: 2026-07-15T09:14:46.442Z
 startTime: 2026-01-16T19:30:22.108Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arc.yml
+++ b/history/safe-tx-service-arc.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/arc/check/
 status: up
 code: 200
-responseTime: 399
-lastUpdated: 2026-07-14T23:40:40.875Z
+responseTime: 465
+lastUpdated: 2026-07-15T09:14:50.940Z
 startTime: 2026-05-22T09:34:40.849Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-aurora.yml
+++ b/history/safe-tx-service-aurora.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-aurora.safe.global/check/
 status: up
 code: 200
-responseTime: 517
-lastUpdated: 2026-07-14T23:40:21.583Z
+responseTime: 465
+lastUpdated: 2026-07-15T09:14:33.382Z
 startTime: 2024-03-19T10:34:30.573Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-avalanche.yml
+++ b/history/safe-tx-service-avalanche.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-avalanche.safe.global/check/
 status: up
 code: 200
-responseTime: 476
-lastUpdated: 2026-07-14T23:40:20.520Z
+responseTime: 466
+lastUpdated: 2026-07-15T09:14:32.383Z
 startTime: 2022-03-25T11:57:26.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-base-mainnet.yml
+++ b/history/safe-tx-service-base-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-base.safe.global/check/
 status: up
 code: 200
-responseTime: 474
-lastUpdated: 2026-07-14T23:40:18.179Z
+responseTime: 463
+lastUpdated: 2026-07-15T09:14:30.382Z
 startTime: 2024-06-14T14:46:55.924Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-base-sepolia.yml
+++ b/history/safe-tx-service-base-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-base-sepolia.safe.global/check/
 status: up
 code: 200
-responseTime: 720
-lastUpdated: 2026-07-14T23:40:18.925Z
+responseTime: 542
+lastUpdated: 2026-07-15T09:14:30.959Z
 startTime: 2024-03-19T10:34:27.349Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-berachain.yml
+++ b/history/safe-tx-service-berachain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-berachain.safe.global/check/
 status: up
 code: 200
-responseTime: 556
-lastUpdated: 2026-07-14T23:40:27.798Z
+responseTime: 468
+lastUpdated: 2026-07-15T09:14:38.385Z
 startTime: 2025-02-17T09:20:55.646Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-binance-smart-chain.yml
+++ b/history/safe-tx-service-binance-smart-chain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-bsc.safe.global/check/
 status: up
 code: 200
-responseTime: 474
-lastUpdated: 2026-07-14T23:40:16.559Z
+responseTime: 514
+lastUpdated: 2026-07-15T09:14:28.692Z
 startTime: 2021-08-05T10:30:17.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-botanix.yml
+++ b/history/safe-tx-service-botanix.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-botanix.safe.global/check/
 status: up
 code: 200
-responseTime: 557
-lastUpdated: 2026-07-14T23:40:32.251Z
+responseTime: 467
+lastUpdated: 2026-07-15T09:14:42.442Z
 startTime: 2025-08-27T12:42:17.067Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-botchain.yml
+++ b/history/safe-tx-service-botchain.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/bot/check/
 status: up
 code: 200
-responseTime: 473
-lastUpdated: 2026-07-14T23:40:42.876Z
+responseTime: 465
+lastUpdated: 2026-07-15T09:14:52.941Z
 startTime: 2026-07-07T09:27:14.783Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-celo-sepolia.yml
+++ b/history/safe-tx-service-celo-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/celo-sep/check/
 status: up
 code: 200
-responseTime: 388
-lastUpdated: 2026-07-14T23:40:40.377Z
+responseTime: 466
+lastUpdated: 2026-07-15T09:14:50.442Z
 startTime: 2026-04-28T07:36:23.579Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-celo.yml
+++ b/history/safe-tx-service-celo.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-celo.safe.global/check/
 status: up
 code: 200
-responseTime: 570
-lastUpdated: 2026-07-14T23:40:19.522Z
+responseTime: 389
+lastUpdated: 2026-07-15T09:14:31.382Z
 startTime: 2023-05-23T15:39:32.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-chiado.yml
+++ b/history/safe-tx-service-chiado.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-chiado.safe.global/check/
 status: up
 code: 200
-responseTime: 580
-lastUpdated: 2026-07-14T23:40:24.971Z
+responseTime: 471
+lastUpdated: 2026-07-15T09:14:35.886Z
 startTime: 2024-08-16T10:52:40.346Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-codex.yml
+++ b/history/safe-tx-service-codex.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-codex.safe.global/check/
 status: up
 code: 200
-responseTime: 483
-lastUpdated: 2026-07-14T23:40:30.594Z
+responseTime: 464
+lastUpdated: 2026-07-15T09:14:40.940Z
 startTime: 2025-07-15T12:51:17.948Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-creditcoin.yml
+++ b/history/safe-tx-service-creditcoin.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/ctc/check/
 status: up
 code: 200
-responseTime: 475
-lastUpdated: 2026-07-14T23:40:36.876Z
+responseTime: 464
+lastUpdated: 2026-07-15T09:14:46.939Z
 startTime: 2026-03-06T09:26:54.038Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-fluent.yml
+++ b/history/safe-tx-service-fluent.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/fluent/check/
 status: up
 code: 200
-responseTime: 475
-lastUpdated: 2026-07-14T23:40:38.877Z
+responseTime: 464
+lastUpdated: 2026-07-15T09:14:48.941Z
 startTime: 2026-04-08T07:35:21.962Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-gnosis-chain.yml
+++ b/history/safe-tx-service-gnosis-chain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-gnosis-chain.safe.global/check/
 status: up
 code: 200
-responseTime: 832
-lastUpdated: 2026-07-14T23:40:15.196Z
+responseTime: 468
+lastUpdated: 2026-07-15T09:14:27.646Z
 startTime: 2022-12-21T17:20:44.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-hemi.yml
+++ b/history/safe-tx-service-hemi.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-hemi.safe.global/check/
 status: up
 code: 200
-responseTime: 567
-lastUpdated: 2026-07-14T23:40:29.024Z
+responseTime: 524
+lastUpdated: 2026-07-15T09:14:39.440Z
 startTime: 2025-04-29T10:31:54.263Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-hyper-evm.yml
+++ b/history/safe-tx-service-hyper-evm.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/hyper/check/
 status: up
 code: 200
-responseTime: 476
-lastUpdated: 2026-07-14T23:40:35.377Z
+responseTime: 468
+lastUpdated: 2026-07-15T09:14:45.442Z
 startTime: 2025-11-19T09:51:43.815Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-ink.yml
+++ b/history/safe-tx-service-ink.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-ink.safe.global/check/
 status: up
 code: 200
-responseTime: 471
-lastUpdated: 2026-07-14T23:40:26.656Z
+responseTime: 468
+lastUpdated: 2026-07-15T09:14:37.384Z
 startTime: 2024-12-12T17:15:05.125Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-kaia.yml
+++ b/history/safe-tx-service-kaia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/kaia/check/
 status: up
 code: 200
-responseTime: 478
-lastUpdated: 2026-07-14T23:40:42.377Z
+responseTime: 467
+lastUpdated: 2026-07-15T09:14:52.443Z
 startTime: 2026-06-12T08:10:32.754Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-kairos.yml
+++ b/history/safe-tx-service-kairos.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/kairos/check/
 status: up
 code: 200
-responseTime: 473
-lastUpdated: 2026-07-14T23:40:41.875Z
+responseTime: 469
+lastUpdated: 2026-07-15T09:14:51.943Z
 startTime: 2026-05-28T09:18:51.609Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-katana.yml
+++ b/history/safe-tx-service-katana.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-katana.safe.global/check/
 status: up
 code: 200
-responseTime: 526
-lastUpdated: 2026-07-14T23:40:29.576Z
+responseTime: 464
+lastUpdated: 2026-07-15T09:14:39.938Z
 startTime: 2025-06-12T12:51:37.947Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-lens.yml
+++ b/history/safe-tx-service-lens.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-lens.safe.global/check/
 status: up
 code: 200
-responseTime: 607
-lastUpdated: 2026-07-14T23:40:28.431Z
+responseTime: 465
+lastUpdated: 2026-07-15T09:14:38.883Z
 startTime: 2025-04-29T10:31:53.750Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-linea.yml
+++ b/history/safe-tx-service-linea.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-linea.safe.global/check/
 status: up
 code: 200
-responseTime: 476
-lastUpdated: 2026-07-14T23:40:24.354Z
+responseTime: 467
+lastUpdated: 2026-07-15T09:14:35.382Z
 startTime: 2024-08-13T14:27:58.910Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mainnet.yml
+++ b/history/safe-tx-service-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-mainnet.safe.global/check/
 status: up
 code: 200
-responseTime: 721
-lastUpdated: 2026-07-14T23:40:14.338Z
+responseTime: 374
+lastUpdated: 2026-07-15T09:14:27.145Z
 startTime: 2021-08-05T10:30:13.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mantle-sepolia.yml
+++ b/history/safe-tx-service-mantle-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/mnt-sep/check/
 status: up
 code: 200
-responseTime: 474
-lastUpdated: 2026-07-14T23:40:37.376Z
+responseTime: 466
+lastUpdated: 2026-07-15T09:14:47.440Z
 startTime: 2026-03-09T14:14:37.684Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mantle.yml
+++ b/history/safe-tx-service-mantle.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-mantle.safe.global/check/
 status: up
 code: 200
-responseTime: 577
-lastUpdated: 2026-07-14T23:40:25.574Z
+responseTime: 477
+lastUpdated: 2026-07-15T09:14:36.396Z
 startTime: 2024-09-23T12:22:22.690Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mega-eth.yml
+++ b/history/safe-tx-service-mega-eth.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/mega/check/
 status: up
 code: 200
-responseTime: 474
-lastUpdated: 2026-07-14T23:40:35.875Z
+responseTime: 469
+lastUpdated: 2026-07-15T09:14:45.943Z
 startTime: 2025-11-19T09:51:44.285Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-monad-testnet.yml
+++ b/history/safe-tx-service-monad-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/monad-testnet/check/
 status: up
 code: 200
-responseTime: 475
-lastUpdated: 2026-07-14T23:40:34.876Z
+responseTime: 467
+lastUpdated: 2026-07-15T09:14:44.941Z
 startTime: 2025-11-19T09:51:43.117Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-monad.yml
+++ b/history/safe-tx-service-monad.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-monad.safe.global/check/
 status: up
 code: 200
-responseTime: 545
-lastUpdated: 2026-07-14T23:40:31.165Z
+responseTime: 468
+lastUpdated: 2026-07-15T09:14:41.441Z
 startTime: 2025-07-23T17:37:01.782Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-op-bnb.yml
+++ b/history/safe-tx-service-op-bnb.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-opbnb.safe.global/check/
 status: up
 code: 200
-responseTime: 477
-lastUpdated: 2026-07-14T23:40:31.668Z
+responseTime: 467
+lastUpdated: 2026-07-15T09:14:41.942Z
 startTime: 2025-08-27T12:42:16.466Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-optimism.yml
+++ b/history/safe-tx-service-optimism.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-optimism.safe.global/check/
 status: up
 code: 200
-responseTime: 479
-lastUpdated: 2026-07-14T23:40:21.025Z
+responseTime: 466
+lastUpdated: 2026-07-15T09:14:32.883Z
 startTime: 2022-04-27T08:51:31.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-peaq.yml
+++ b/history/safe-tx-service-peaq.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-peaq.safe.global/check/
 status: up
 code: 200
-responseTime: 474
-lastUpdated: 2026-07-14T23:40:30.076Z
+responseTime: 468
+lastUpdated: 2026-07-15T09:14:40.441Z
 startTime: 2025-06-19T11:04:40.586Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-pharos.yml
+++ b/history/safe-tx-service-pharos.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/pharos/check/
 status: up
 code: 200
-responseTime: 472
-lastUpdated: 2026-07-14T23:40:39.874Z
+responseTime: 468
+lastUpdated: 2026-07-15T09:14:49.942Z
 startTime: 2026-04-24T10:19:44.208Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-plasma.yml
+++ b/history/safe-tx-service-plasma.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/plasma/check/
 status: up
 code: 200
-responseTime: 472
-lastUpdated: 2026-07-14T23:40:33.374Z
+responseTime: 466
+lastUpdated: 2026-07-15T09:14:43.441Z
 startTime: 2025-11-19T09:51:41.442Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-polygon-matic.yml
+++ b/history/safe-tx-service-polygon-matic.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-polygon.safe.global/check/
 status: up
 code: 200
-responseTime: 464
-lastUpdated: 2026-07-14T23:40:17.058Z
+responseTime: 654
+lastUpdated: 2026-07-15T09:14:29.382Z
 startTime: 2021-08-05T10:30:18.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-polygon-zk-evm.yml
+++ b/history/safe-tx-service-polygon-zk-evm.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-zkevm.safe.global/check/
 status: up
 code: 200
-responseTime: 583
-lastUpdated: 2026-07-14T23:40:17.679Z
+responseTime: 462
+lastUpdated: 2026-07-15T09:14:29.884Z
 startTime: 2024-03-19T10:34:26.788Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-robinhood-testnet.yml
+++ b/history/safe-tx-service-robinhood-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/robinhood-testnet/check/
 status: up
 code: 200
-responseTime: 455
-lastUpdated: 2026-07-14T23:40:39.377Z
+responseTime: 466
+lastUpdated: 2026-07-15T09:14:49.440Z
 startTime: 2026-04-13T11:40:23.659Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-scroll.yml
+++ b/history/safe-tx-service-scroll.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-scroll.safe.global/check/
 status: up
 code: 200
-responseTime: 595
-lastUpdated: 2026-07-14T23:40:23.853Z
+responseTime: 465
+lastUpdated: 2026-07-15T09:14:34.882Z
 startTime: 2024-06-14T14:47:02.950Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-sepolia.yml
+++ b/history/safe-tx-service-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-sepolia.safe.global/check/
 status: up
 code: 200
-responseTime: 670
-lastUpdated: 2026-07-14T23:40:16.060Z
+responseTime: 466
+lastUpdated: 2026-07-15T09:14:28.146Z
 startTime: 2024-03-19T10:34:24.824Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-sonic.yml
+++ b/history/safe-tx-service-sonic.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-sonic.safe.global/check/
 status: up
 code: 200
-responseTime: 534
-lastUpdated: 2026-07-14T23:40:26.159Z
+responseTime: 453
+lastUpdated: 2026-07-15T09:14:36.882Z
 startTime: 2024-12-11T12:21:10.129Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-stable.yml
+++ b/history/safe-tx-service-stable.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/stable/check/
 status: up
 code: 200
-responseTime: 475
-lastUpdated: 2026-07-14T23:40:34.377Z
+responseTime: 427
+lastUpdated: 2026-07-15T09:14:44.442Z
 startTime: 2025-11-19T09:51:42.637Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-tempo-moderato.yml
+++ b/history/safe-tx-service-tempo-moderato.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/tempo-moderato/check/
 status: up
 code: 200
-responseTime: 472
-lastUpdated: 2026-07-14T23:40:37.873Z
+responseTime: 467
+lastUpdated: 2026-07-15T09:14:47.939Z
 startTime: 2026-03-13T10:03:54.843Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-tempo.yml
+++ b/history/safe-tx-service-tempo.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/tempo/check/
 status: up
 code: 200
-responseTime: 479
-lastUpdated: 2026-07-14T23:40:38.377Z
+responseTime: 470
+lastUpdated: 2026-07-15T09:14:48.444Z
 startTime: 2026-03-19T20:50:55.701Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-unichain.yml
+++ b/history/safe-tx-service-unichain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-unichain.safe.global/check/
 status: up
 code: 200
-responseTime: 533
-lastUpdated: 2026-07-14T23:40:27.216Z
+responseTime: 465
+lastUpdated: 2026-07-15T09:14:37.883Z
 startTime: 2025-02-04T11:44:48.395Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-whitechain-sepolia.yml
+++ b/history/safe-tx-service-whitechain-sepolia.yml
@@ -1,0 +1,7 @@
+url: https://api.safe.global/tx-service/wch-sepolia/check/
+status: down
+code: 404
+responseTime: 193
+lastUpdated: 2026-07-15T09:15:05.827Z
+startTime: 2026-07-15T09:14:52.971Z
+generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-x-layer.yml
+++ b/history/safe-tx-service-x-layer.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-xlayer.safe.global/check/
 status: up
 code: 200
-responseTime: 556
-lastUpdated: 2026-07-14T23:40:22.880Z
+responseTime: 467
+lastUpdated: 2026-07-15T09:14:34.384Z
 startTime: 2024-06-14T14:47:02.024Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-xdc.yml
+++ b/history/safe-tx-service-xdc.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-xdc.safe.global/check/
 status: up
 code: 200
-responseTime: 601
-lastUpdated: 2026-07-14T23:40:32.877Z
+responseTime: 465
+lastUpdated: 2026-07-15T09:14:42.940Z
 startTime: 2025-08-27T12:42:17.701Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-zk-sync-era-mainnet.yml
+++ b/history/safe-tx-service-zk-sync-era-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-zksync.safe.global/check/
 status: up
 code: 200
-responseTime: 689
-lastUpdated: 2026-07-14T23:40:22.298Z
+responseTime: 467
+lastUpdated: 2026-07-15T09:14:33.884Z
 startTime: 2024-03-19T10:34:31.311Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
Adds the Whitechain Sepolia tx-service check to uptime.safe.global, hitting `https://api.safe.global/tx-service/wch-sepolia/check/`. The chain 1874 logo asset isn't uploaded yet (currently 403), so the icon will render once the assets team adds it.

Refs CLOUD-971.
