### PR TITLE
feat: Add whitechain-sepolia uptime monitoring

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -162,6 +162,9 @@ sites:
   - name: Safe Tx Service (Botchain)
     url: https://api.safe.global/tx-service/bot/check/
     icon: https://safe-transaction-assets.safe.global/chains/677/chain_logo.png
+  - name: Safe Tx Service (Whitechain Sepolia)
+    url: https://api.safe.global/tx-service/wch-sepolia/check/
+    icon: https://safe-transaction-assets.safe.global/chains/1874/chain_logo.png
 status-website:
   # Add your custom domain name, or remove the `cname` line if you don't have a domain
   # Uncomment the `baseUrl` line if you don't have a custom domain and add your repo name there

--- a/history/safe-client-gateway.yml
+++ b/history/safe-client-gateway.yml
@@ -1,7 +1,7 @@
 url: https://safe-client.safe.global/health/ready/
 status: up
 code: 200
-responseTime: 187
-lastUpdated: 2026-07-15T23:47:00.568Z
+responseTime: 264
+lastUpdated: 2026-07-16T13:17:29.864Z
 startTime: 2024-06-14T14:46:50.293Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-0g.yml
+++ b/history/safe-tx-service-0g.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/0g/check/
 status: up
 code: 200
-responseTime: 192
-lastUpdated: 2026-07-16T04:17:04.026Z
+responseTime: 470
+lastUpdated: 2026-07-16T13:17:48.978Z
 startTime: 2025-11-19T09:51:42.016Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-aetherium.yml
+++ b/history/safe-tx-service-aetherium.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/aeth/check/
 status: up
 code: 200
-responseTime: 196
-lastUpdated: 2026-07-16T04:17:44.250Z
+responseTime: 488
+lastUpdated: 2026-07-16T13:17:56.498Z
 startTime: 2026-05-26T08:27:19.516Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arbitrum.yml
+++ b/history/safe-tx-service-arbitrum.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-arbitrum.safe.global/check/
 status: up
 code: 200
-responseTime: 476
-lastUpdated: 2026-07-16T04:15:53.423Z
+responseTime: 618
+lastUpdated: 2026-07-16T13:17:35.688Z
 startTime: 2021-08-05T10:30:22.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arc-testnet.yml
+++ b/history/safe-tx-service-arc-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/arc-testnet/check/
 status: up
 code: 200
-responseTime: 188
-lastUpdated: 2026-07-16T04:17:18.148Z
+responseTime: 509
+lastUpdated: 2026-07-16T13:17:51.520Z
 startTime: 2026-01-16T19:30:22.108Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arc.yml
+++ b/history/safe-tx-service-arc.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/arc/check/
 status: up
 code: 200
-responseTime: 192
-lastUpdated: 2026-07-16T04:17:41.592Z
+responseTime: 470
+lastUpdated: 2026-07-16T13:17:55.979Z
 startTime: 2026-05-22T09:34:40.849Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-aurora.yml
+++ b/history/safe-tx-service-aurora.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-aurora.safe.global/check/
 status: up
 code: 200
-responseTime: 515
-lastUpdated: 2026-07-16T04:16:02.572Z
+responseTime: 492
+lastUpdated: 2026-07-16T13:17:37.279Z
 startTime: 2024-03-19T10:34:30.573Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-avalanche.yml
+++ b/history/safe-tx-service-avalanche.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-avalanche.safe.global/check/
 status: up
 code: 200
-responseTime: 457
-lastUpdated: 2026-07-16T04:15:56.457Z
+responseTime: 535
+lastUpdated: 2026-07-16T13:17:36.255Z
 startTime: 2022-03-25T11:57:26.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-base-mainnet.yml
+++ b/history/safe-tx-service-base-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-base.safe.global/check/
 status: up
 code: 200
-responseTime: 587
-lastUpdated: 2026-07-16T04:15:44.611Z
+responseTime: 672
+lastUpdated: 2026-07-16T13:17:34.040Z
 startTime: 2024-06-14T14:46:55.924Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-base-sepolia.yml
+++ b/history/safe-tx-service-base-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-base-sepolia.safe.global/check/
 status: up
 code: 200
-responseTime: 530
-lastUpdated: 2026-07-16T04:15:47.600Z
+responseTime: 460
+lastUpdated: 2026-07-16T13:17:34.538Z
 startTime: 2024-03-19T10:34:27.349Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-berachain.yml
+++ b/history/safe-tx-service-berachain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-berachain.safe.global/check/
 status: up
 code: 200
-responseTime: 458
-lastUpdated: 2026-07-16T04:16:32.786Z
+responseTime: 550
+lastUpdated: 2026-07-16T13:17:42.895Z
 startTime: 2025-02-17T09:20:55.646Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-binance-smart-chain.yml
+++ b/history/safe-tx-service-binance-smart-chain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-bsc.safe.global/check/
 status: up
 code: 200
-responseTime: 493
-lastUpdated: 2026-07-16T04:15:35.465Z
+responseTime: 499
+lastUpdated: 2026-07-16T13:17:32.334Z
 startTime: 2021-08-05T10:30:17.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-botanix.yml
+++ b/history/safe-tx-service-botanix.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-botanix.safe.global/check/
 status: up
 code: 200
-responseTime: 483
-lastUpdated: 2026-07-16T04:16:55.827Z
+responseTime: 468
+lastUpdated: 2026-07-16T13:17:47.478Z
 startTime: 2025-08-27T12:42:17.067Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-botchain.yml
+++ b/history/safe-tx-service-botchain.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/bot/check/
 status: up
 code: 200
-responseTime: 191
-lastUpdated: 2026-07-16T04:17:52.047Z
+responseTime: 470
+lastUpdated: 2026-07-16T13:17:57.978Z
 startTime: 2026-07-07T09:27:14.783Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-celo-sepolia.yml
+++ b/history/safe-tx-service-celo-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/celo-sep/check/
 status: up
 code: 200
-responseTime: 188
-lastUpdated: 2026-07-16T04:17:38.986Z
+responseTime: 468
+lastUpdated: 2026-07-16T13:17:55.477Z
 startTime: 2026-04-28T07:36:23.579Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-celo.yml
+++ b/history/safe-tx-service-celo.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-celo.safe.global/check/
 status: up
 code: 200
-responseTime: 506
-lastUpdated: 2026-07-16T04:15:50.583Z
+responseTime: 469
+lastUpdated: 2026-07-16T13:17:35.038Z
 startTime: 2023-05-23T15:39:32.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-chiado.yml
+++ b/history/safe-tx-service-chiado.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-chiado.safe.global/check/
 status: up
 code: 200
-responseTime: 506
-lastUpdated: 2026-07-16T04:16:17.300Z
+responseTime: 694
+lastUpdated: 2026-07-16T13:17:40.244Z
 startTime: 2024-08-16T10:52:40.346Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-codex.yml
+++ b/history/safe-tx-service-codex.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-codex.safe.global/check/
 status: up
 code: 200
-responseTime: 522
-lastUpdated: 2026-07-16T04:16:47.139Z
+responseTime: 731
+lastUpdated: 2026-07-16T13:17:45.747Z
 startTime: 2025-07-15T12:51:17.948Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-creditcoin.yml
+++ b/history/safe-tx-service-creditcoin.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/ctc/check/
 status: up
 code: 200
-responseTime: 204
-lastUpdated: 2026-07-16T04:17:20.764Z
+responseTime: 427
+lastUpdated: 2026-07-16T13:17:51.979Z
 startTime: 2026-03-06T09:26:54.038Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-fluent.yml
+++ b/history/safe-tx-service-fluent.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/fluent/check/
 status: up
 code: 200
-responseTime: 190
-lastUpdated: 2026-07-16T04:17:31.119Z
+responseTime: 470
+lastUpdated: 2026-07-16T13:17:53.978Z
 startTime: 2026-04-08T07:35:21.962Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-gnosis-chain.yml
+++ b/history/safe-tx-service-gnosis-chain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-gnosis-chain.safe.global/check/
 status: up
 code: 200
-responseTime: 741
-lastUpdated: 2026-07-16T04:15:29.224Z
+responseTime: 694
+lastUpdated: 2026-07-16T13:17:31.289Z
 startTime: 2022-12-21T17:20:44.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-hemi.yml
+++ b/history/safe-tx-service-hemi.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-hemi.safe.global/check/
 status: up
 code: 200
-responseTime: 587
-lastUpdated: 2026-07-16T04:16:38.635Z
+responseTime: 468
+lastUpdated: 2026-07-16T13:17:43.913Z
 startTime: 2025-04-29T10:31:54.263Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-hyper-evm.yml
+++ b/history/safe-tx-service-hyper-evm.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/hyper/check/
 status: up
 code: 200
-responseTime: 195
-lastUpdated: 2026-07-16T04:17:12.886Z
+responseTime: 464
+lastUpdated: 2026-07-16T13:17:50.478Z
 startTime: 2025-11-19T09:51:43.815Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-ink.yml
+++ b/history/safe-tx-service-ink.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-ink.safe.global/check/
 status: up
 code: 200
-responseTime: 502
-lastUpdated: 2026-07-16T04:16:26.782Z
+responseTime: 496
+lastUpdated: 2026-07-16T13:17:41.814Z
 startTime: 2024-12-12T17:15:05.125Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-kaia.yml
+++ b/history/safe-tx-service-kaia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/kaia/check/
 status: up
 code: 200
-responseTime: 190
-lastUpdated: 2026-07-16T04:17:49.538Z
+responseTime: 467
+lastUpdated: 2026-07-16T13:17:57.477Z
 startTime: 2026-06-12T08:10:32.754Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-kairos.yml
+++ b/history/safe-tx-service-kairos.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/kairos/check/
 status: up
 code: 200
-responseTime: 189
-lastUpdated: 2026-07-16T04:17:46.787Z
+responseTime: 449
+lastUpdated: 2026-07-16T13:17:56.977Z
 startTime: 2026-05-28T09:18:51.609Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-katana.yml
+++ b/history/safe-tx-service-katana.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-katana.safe.global/check/
 status: up
 code: 200
-responseTime: 510
-lastUpdated: 2026-07-16T04:16:41.506Z
+responseTime: 466
+lastUpdated: 2026-07-16T13:17:44.412Z
 startTime: 2025-06-12T12:51:37.947Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-lens.yml
+++ b/history/safe-tx-service-lens.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-lens.safe.global/check/
 status: up
 code: 200
-responseTime: 511
-lastUpdated: 2026-07-16T04:16:35.800Z
+responseTime: 487
+lastUpdated: 2026-07-16T13:17:43.414Z
 startTime: 2025-04-29T10:31:53.750Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-linea.yml
+++ b/history/safe-tx-service-linea.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-linea.safe.global/check/
 status: up
 code: 200
-responseTime: 546
-lastUpdated: 2026-07-16T04:16:14.330Z
+responseTime: 487
+lastUpdated: 2026-07-16T13:17:39.518Z
 startTime: 2024-08-13T14:27:58.910Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mainnet.yml
+++ b/history/safe-tx-service-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-mainnet.safe.global/check/
 status: up
 code: 200
-responseTime: 592
-lastUpdated: 2026-07-16T04:15:26.166Z
+responseTime: 633
+lastUpdated: 2026-07-16T13:17:30.563Z
 startTime: 2021-08-05T10:30:13.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mantle-sepolia.yml
+++ b/history/safe-tx-service-mantle-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/mnt-sep/check/
 status: up
 code: 200
-responseTime: 189
-lastUpdated: 2026-07-16T04:17:23.299Z
+responseTime: 468
+lastUpdated: 2026-07-16T13:17:52.478Z
 startTime: 2026-03-09T14:14:37.684Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mantle.yml
+++ b/history/safe-tx-service-mantle.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-mantle.safe.global/check/
 status: up
 code: 200
-responseTime: 595
-lastUpdated: 2026-07-16T04:16:20.490Z
+responseTime: 469
+lastUpdated: 2026-07-16T13:17:40.744Z
 startTime: 2024-09-23T12:22:22.690Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mega-eth.yml
+++ b/history/safe-tx-service-mega-eth.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/mega/check/
 status: up
 code: 200
-responseTime: 195
-lastUpdated: 2026-07-16T04:17:15.530Z
+responseTime: 470
+lastUpdated: 2026-07-16T13:17:50.980Z
 startTime: 2025-11-19T09:51:44.285Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-monad-testnet.yml
+++ b/history/safe-tx-service-monad-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/monad-testnet/check/
 status: up
 code: 200
-responseTime: 197
-lastUpdated: 2026-07-16T04:17:09.789Z
+responseTime: 475
+lastUpdated: 2026-07-16T13:17:49.983Z
 startTime: 2025-11-19T09:51:43.117Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-monad.yml
+++ b/history/safe-tx-service-monad.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-monad.safe.global/check/
 status: up
 code: 200
-responseTime: 569
-lastUpdated: 2026-07-16T04:16:50.261Z
+responseTime: 567
+lastUpdated: 2026-07-16T13:17:46.346Z
 startTime: 2025-07-23T17:37:01.782Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-op-bnb.yml
+++ b/history/safe-tx-service-op-bnb.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-opbnb.safe.global/check/
 status: up
 code: 200
-responseTime: 415
-lastUpdated: 2026-07-16T04:16:53.055Z
+responseTime: 602
+lastUpdated: 2026-07-16T13:17:46.979Z
 startTime: 2025-08-27T12:42:16.466Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-optimism.yml
+++ b/history/safe-tx-service-optimism.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-optimism.safe.global/check/
 status: up
 code: 200
-responseTime: 409
-lastUpdated: 2026-07-16T04:15:59.329Z
+responseTime: 468
+lastUpdated: 2026-07-16T13:17:36.755Z
 startTime: 2022-04-27T08:51:31.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-peaq.yml
+++ b/history/safe-tx-service-peaq.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-peaq.safe.global/check/
 status: up
 code: 200
-responseTime: 419
-lastUpdated: 2026-07-16T04:16:44.240Z
+responseTime: 470
+lastUpdated: 2026-07-16T13:17:44.914Z
 startTime: 2025-06-19T11:04:40.586Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-pharos.yml
+++ b/history/safe-tx-service-pharos.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/pharos/check/
 status: up
 code: 200
-responseTime: 191
-lastUpdated: 2026-07-16T04:17:36.238Z
+responseTime: 469
+lastUpdated: 2026-07-16T13:17:54.978Z
 startTime: 2026-04-24T10:19:44.208Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-plasma.yml
+++ b/history/safe-tx-service-plasma.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/plasma/check/
 status: up
 code: 200
-responseTime: 225
-lastUpdated: 2026-07-16T04:17:01.356Z
+responseTime: 466
+lastUpdated: 2026-07-16T13:17:48.477Z
 startTime: 2025-11-19T09:51:41.442Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-polygon-matic.yml
+++ b/history/safe-tx-service-polygon-matic.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-polygon.safe.global/check/
 status: up
 code: 200
-responseTime: 620
-lastUpdated: 2026-07-16T04:15:38.451Z
+responseTime: 462
+lastUpdated: 2026-07-16T13:17:32.835Z
 startTime: 2021-08-05T10:30:18.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-polygon-zk-evm.yml
+++ b/history/safe-tx-service-polygon-zk-evm.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-zkevm.safe.global/check/
 status: up
 code: 200
-responseTime: 554
-lastUpdated: 2026-07-16T04:15:41.647Z
+responseTime: 468
+lastUpdated: 2026-07-16T13:17:33.335Z
 startTime: 2024-03-19T10:34:26.788Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-robinhood-testnet.yml
+++ b/history/safe-tx-service-robinhood-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/robinhood-testnet/check/
 status: up
 code: 200
-responseTime: 222
-lastUpdated: 2026-07-16T04:17:33.732Z
+responseTime: 468
+lastUpdated: 2026-07-16T13:17:54.478Z
 startTime: 2026-04-13T11:40:23.659Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-scroll.yml
+++ b/history/safe-tx-service-scroll.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-scroll.safe.global/check/
 status: up
 code: 200
-responseTime: 445
-lastUpdated: 2026-07-16T04:16:11.305Z
+responseTime: 467
+lastUpdated: 2026-07-16T13:17:39.000Z
 startTime: 2024-06-14T14:47:02.950Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-sepolia.yml
+++ b/history/safe-tx-service-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-sepolia.safe.global/check/
 status: up
 code: 200
-responseTime: 661
-lastUpdated: 2026-07-16T04:15:32.566Z
+responseTime: 480
+lastUpdated: 2026-07-16T13:17:31.803Z
 startTime: 2024-03-19T10:34:24.824Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-sonic.yml
+++ b/history/safe-tx-service-sonic.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-sonic.safe.global/check/
 status: up
 code: 200
-responseTime: 894
-lastUpdated: 2026-07-16T04:16:23.909Z
+responseTime: 513
+lastUpdated: 2026-07-16T13:17:41.287Z
 startTime: 2024-12-11T12:21:10.129Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-stable.yml
+++ b/history/safe-tx-service-stable.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/stable/check/
 status: up
 code: 200
-responseTime: 191
-lastUpdated: 2026-07-16T04:17:06.987Z
+responseTime: 467
+lastUpdated: 2026-07-16T13:17:49.477Z
 startTime: 2025-11-19T09:51:42.637Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-tempo-moderato.yml
+++ b/history/safe-tx-service-tempo-moderato.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/tempo-moderato/check/
 status: up
 code: 200
-responseTime: 194
-lastUpdated: 2026-07-16T04:17:26.033Z
+responseTime: 468
+lastUpdated: 2026-07-16T13:17:52.978Z
 startTime: 2026-03-13T10:03:54.843Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-tempo.yml
+++ b/history/safe-tx-service-tempo.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/tempo/check/
 status: up
 code: 200
-responseTime: 226
-lastUpdated: 2026-07-16T04:17:28.554Z
+responseTime: 467
+lastUpdated: 2026-07-16T13:17:53.478Z
 startTime: 2026-03-19T20:50:55.701Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-unichain.yml
+++ b/history/safe-tx-service-unichain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-unichain.safe.global/check/
 status: up
 code: 200
-responseTime: 561
-lastUpdated: 2026-07-16T04:16:29.970Z
+responseTime: 466
+lastUpdated: 2026-07-16T13:17:42.313Z
 startTime: 2025-02-04T11:44:48.395Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-whitechain-sepolia.yml
+++ b/history/safe-tx-service-whitechain-sepolia.yml
@@ -1,0 +1,7 @@
+url: https://api.safe.global/tx-service/wch-sepolia/check/
+status: up
+code: 200
+responseTime: 471
+lastUpdated: 2026-07-16T13:17:58.480Z
+startTime: 2026-07-16T13:17:58.007Z
+generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-x-layer.yml
+++ b/history/safe-tx-service-x-layer.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-xlayer.safe.global/check/
 status: up
 code: 200
-responseTime: 566
-lastUpdated: 2026-07-16T04:16:08.597Z
+responseTime: 468
+lastUpdated: 2026-07-16T13:17:38.501Z
 startTime: 2024-06-14T14:47:02.024Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-xdc.yml
+++ b/history/safe-tx-service-xdc.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-xdc.safe.global/check/
 status: up
 code: 200
-responseTime: 457
-lastUpdated: 2026-07-16T04:16:58.575Z
+responseTime: 471
+lastUpdated: 2026-07-16T13:17:47.980Z
 startTime: 2025-08-27T12:42:17.701Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-zk-sync-era-mainnet.yml
+++ b/history/safe-tx-service-zk-sync-era-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-zksync.safe.global/check/
 status: up
 code: 200
-responseTime: 632
-lastUpdated: 2026-07-16T04:16:05.576Z
+responseTime: 688
+lastUpdated: 2026-07-16T13:17:38.001Z
 startTime: 2024-03-19T10:34:31.311Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
Adds the Whitechain Sepolia tx-service check to uptime.safe.global (`https://api.safe.global/tx-service/wch-sepolia/check/`).

Replaces #19457, which conflicted after master moved. The chain 1874 logo asset may still 404 until the assets team uploads it (icon is cosmetic).

Refs CLOUD-971.
