### PR TITLE
chore: Remove zkevm uptime monitoring

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -21,9 +21,6 @@ sites:
   - name: Safe Tx Service (Polygon - Matic)
     url: https://safe-transaction-polygon.safe.global/check/
     icon: https://safe-transaction-assets.safe.global/chains/137/chain_logo.png
-  - name: Safe Tx Service (Polygon - zkEVM)
-    url: https://safe-transaction-zkevm.safe.global/check/
-    icon: https://safe-transaction-assets.safe.global/chains/1101/chain_logo.png
   - name: Safe Tx Service (Base Mainnet)
     url: https://safe-transaction-base.safe.global/check/
     icon: https://safe-transaction-assets.safe.global/chains/8453/chain_logo.png

--- a/history/safe-client-gateway.yml
+++ b/history/safe-client-gateway.yml
@@ -1,7 +1,7 @@
 url: https://safe-client.safe.global/health/ready/
 status: up
 code: 200
-responseTime: 199
-lastUpdated: 2026-07-24T23:54:35.824Z
+responseTime: 136
+lastUpdated: 2026-07-25T07:50:40.302Z
 startTime: 2024-06-14T14:46:50.293Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-0g.yml
+++ b/history/safe-tx-service-0g.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/0g/check/
 status: up
 code: 200
-responseTime: 467
-lastUpdated: 2026-07-24T23:54:53.128Z
+responseTime: 469
+lastUpdated: 2026-07-25T07:50:57.288Z
 startTime: 2025-11-19T09:51:42.016Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-aetherium.yml
+++ b/history/safe-tx-service-aetherium.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/aeth/check/
 status: up
 code: 200
-responseTime: 461
-lastUpdated: 2026-07-24T23:55:00.628Z
+responseTime: 468
+lastUpdated: 2026-07-25T07:51:04.788Z
 startTime: 2026-05-26T08:27:19.516Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arbitrum.yml
+++ b/history/safe-tx-service-arbitrum.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-arbitrum.safe.global/check/
 status: up
 code: 200
-responseTime: 463
-lastUpdated: 2026-07-24T23:54:41.126Z
+responseTime: 375
+lastUpdated: 2026-07-25T07:50:45.062Z
 startTime: 2021-08-05T10:30:22.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arc-testnet.yml
+++ b/history/safe-tx-service-arc-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/arc-testnet/check/
 status: up
 code: 200
-responseTime: 462
-lastUpdated: 2026-07-24T23:54:55.626Z
+responseTime: 466
+lastUpdated: 2026-07-25T07:50:59.787Z
 startTime: 2026-01-16T19:30:22.108Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arc.yml
+++ b/history/safe-tx-service-arc.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/arc/check/
 status: up
 code: 200
-responseTime: 471
-lastUpdated: 2026-07-24T23:55:00.132Z
+responseTime: 467
+lastUpdated: 2026-07-25T07:51:04.287Z
 startTime: 2026-05-22T09:34:40.849Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-aurora.yml
+++ b/history/safe-tx-service-aurora.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-aurora.safe.global/check/
 status: up
 code: 200
-responseTime: 467
-lastUpdated: 2026-07-24T23:54:42.628Z
+responseTime: 466
+lastUpdated: 2026-07-25T07:50:46.695Z
 startTime: 2024-03-19T10:34:30.573Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-avalanche.yml
+++ b/history/safe-tx-service-avalanche.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-avalanche.safe.global/check/
 status: up
 code: 200
-responseTime: 466
-lastUpdated: 2026-07-24T23:54:41.627Z
+responseTime: 568
+lastUpdated: 2026-07-25T07:50:45.696Z
 startTime: 2022-03-25T11:57:26.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-base-mainnet.yml
+++ b/history/safe-tx-service-base-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-base.safe.global/check/
 status: up
 code: 200
-responseTime: 464
-lastUpdated: 2026-07-24T23:54:39.376Z
+responseTime: 466
+lastUpdated: 2026-07-25T07:50:43.440Z
 startTime: 2024-06-14T14:46:55.924Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-base-sepolia.yml
+++ b/history/safe-tx-service-base-sepolia.yml
@@ -2,6 +2,6 @@ url: https://safe-transaction-base-sepolia.safe.global/check/
 status: up
 code: 200
 responseTime: 466
-lastUpdated: 2026-07-24T23:54:39.876Z
+lastUpdated: 2026-07-25T07:50:43.940Z
 startTime: 2024-03-19T10:34:27.349Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-berachain.yml
+++ b/history/safe-tx-service-berachain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-berachain.safe.global/check/
 status: up
 code: 200
-responseTime: 463
-lastUpdated: 2026-07-24T23:54:47.626Z
+responseTime: 467
+lastUpdated: 2026-07-25T07:50:51.788Z
 startTime: 2025-02-17T09:20:55.646Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-binance-smart-chain.yml
+++ b/history/safe-tx-service-binance-smart-chain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-bsc.safe.global/check/
 status: up
 code: 200
-responseTime: 462
-lastUpdated: 2026-07-24T23:54:37.876Z
+responseTime: 471
+lastUpdated: 2026-07-25T07:50:42.444Z
 startTime: 2021-08-05T10:30:17.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-botanix.yml
+++ b/history/safe-tx-service-botanix.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-botanix.safe.global/check/
 status: up
 code: 200
-responseTime: 461
-lastUpdated: 2026-07-24T23:54:51.627Z
+responseTime: 466
+lastUpdated: 2026-07-25T07:50:55.785Z
 startTime: 2025-08-27T12:42:17.067Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-botchain.yml
+++ b/history/safe-tx-service-botchain.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/bot/check/
 status: up
 code: 200
-responseTime: 467
-lastUpdated: 2026-07-24T23:55:02.128Z
+responseTime: 464
+lastUpdated: 2026-07-25T07:51:06.287Z
 startTime: 2026-07-07T09:27:14.783Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-celo-sepolia.yml
+++ b/history/safe-tx-service-celo-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/celo-sep/check/
 status: up
 code: 200
-responseTime: 463
-lastUpdated: 2026-07-24T23:54:59.626Z
+responseTime: 466
+lastUpdated: 2026-07-25T07:51:03.788Z
 startTime: 2026-04-28T07:36:23.579Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-celo.yml
+++ b/history/safe-tx-service-celo.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-celo.safe.global/check/
 status: up
 code: 200
-responseTime: 716
-lastUpdated: 2026-07-24T23:54:40.627Z
+responseTime: 303
+lastUpdated: 2026-07-25T07:50:44.441Z
 startTime: 2023-05-23T15:39:32.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-chiado.yml
+++ b/history/safe-tx-service-chiado.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-chiado.safe.global/check/
 status: up
 code: 200
-responseTime: 469
-lastUpdated: 2026-07-24T23:54:45.129Z
+responseTime: 468
+lastUpdated: 2026-07-25T07:50:49.197Z
 startTime: 2024-08-16T10:52:40.346Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-codex.yml
+++ b/history/safe-tx-service-codex.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-codex.safe.global/check/
 status: up
 code: 200
-responseTime: 466
-lastUpdated: 2026-07-24T23:54:50.127Z
+responseTime: 467
+lastUpdated: 2026-07-25T07:50:54.288Z
 startTime: 2025-07-15T12:51:17.948Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-creditcoin.yml
+++ b/history/safe-tx-service-creditcoin.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/ctc/check/
 status: up
 code: 200
-responseTime: 468
-lastUpdated: 2026-07-24T23:54:56.129Z
+responseTime: 467
+lastUpdated: 2026-07-25T07:51:00.286Z
 startTime: 2026-03-06T09:26:54.038Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-fluent.yml
+++ b/history/safe-tx-service-fluent.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/fluent/check/
 status: up
 code: 200
-responseTime: 467
-lastUpdated: 2026-07-24T23:54:58.127Z
+responseTime: 458
+lastUpdated: 2026-07-25T07:51:02.289Z
 startTime: 2026-04-08T07:35:21.962Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-gnosis-chain.yml
+++ b/history/safe-tx-service-gnosis-chain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-gnosis-chain.safe.global/check/
 status: up
 code: 200
-responseTime: 456
-lastUpdated: 2026-07-24T23:54:36.877Z
+responseTime: 470
+lastUpdated: 2026-07-25T07:50:41.325Z
 startTime: 2022-12-21T17:20:44.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-hemi.yml
+++ b/history/safe-tx-service-hemi.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-hemi.safe.global/check/
 status: up
 code: 200
-responseTime: 464
-lastUpdated: 2026-07-24T23:54:48.627Z
+responseTime: 465
+lastUpdated: 2026-07-25T07:50:52.788Z
 startTime: 2025-04-29T10:31:54.263Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-hyper-evm.yml
+++ b/history/safe-tx-service-hyper-evm.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/hyper/check/
 status: up
 code: 200
-responseTime: 466
-lastUpdated: 2026-07-24T23:54:54.628Z
+responseTime: 467
+lastUpdated: 2026-07-25T07:50:58.788Z
 startTime: 2025-11-19T09:51:43.815Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-ink.yml
+++ b/history/safe-tx-service-ink.yml
@@ -2,6 +2,6 @@ url: https://safe-transaction-ink.safe.global/check/
 status: up
 code: 200
 responseTime: 467
-lastUpdated: 2026-07-24T23:54:46.628Z
+lastUpdated: 2026-07-25T07:50:50.787Z
 startTime: 2024-12-12T17:15:05.125Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-kaia.yml
+++ b/history/safe-tx-service-kaia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/kaia/check/
 status: up
 code: 200
-responseTime: 466
-lastUpdated: 2026-07-24T23:55:01.628Z
+responseTime: 470
+lastUpdated: 2026-07-25T07:51:05.790Z
 startTime: 2026-06-12T08:10:32.754Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-kairos.yml
+++ b/history/safe-tx-service-kairos.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/kairos/check/
 status: up
 code: 200
-responseTime: 465
-lastUpdated: 2026-07-24T23:55:01.127Z
+responseTime: 466
+lastUpdated: 2026-07-25T07:51:05.287Z
 startTime: 2026-05-28T09:18:51.609Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-katana.yml
+++ b/history/safe-tx-service-katana.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-katana.safe.global/check/
 status: up
 code: 200
-responseTime: 467
-lastUpdated: 2026-07-24T23:54:49.129Z
+responseTime: 465
+lastUpdated: 2026-07-25T07:50:53.287Z
 startTime: 2025-06-12T12:51:37.947Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-lens.yml
+++ b/history/safe-tx-service-lens.yml
@@ -2,6 +2,6 @@ url: https://safe-transaction-lens.safe.global/check/
 status: up
 code: 200
 responseTime: 468
-lastUpdated: 2026-07-24T23:54:48.129Z
+lastUpdated: 2026-07-25T07:50:52.290Z
 startTime: 2025-04-29T10:31:53.750Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-linea.yml
+++ b/history/safe-tx-service-linea.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-linea.safe.global/check/
 status: up
 code: 200
-responseTime: 462
-lastUpdated: 2026-07-24T23:54:44.625Z
+responseTime: 467
+lastUpdated: 2026-07-25T07:50:48.696Z
 startTime: 2024-08-13T14:27:58.910Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mainnet.yml
+++ b/history/safe-tx-service-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-mainnet.safe.global/check/
 status: up
 code: 200
-responseTime: 488
-lastUpdated: 2026-07-24T23:54:36.384Z
+responseTime: 452
+lastUpdated: 2026-07-25T07:50:40.822Z
 startTime: 2021-08-05T10:30:13.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mantle-sepolia.yml
+++ b/history/safe-tx-service-mantle-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/mnt-sep/check/
 status: up
 code: 200
-responseTime: 465
-lastUpdated: 2026-07-24T23:54:56.628Z
+responseTime: 473
+lastUpdated: 2026-07-25T07:51:00.792Z
 startTime: 2026-03-09T14:14:37.684Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mantle.yml
+++ b/history/safe-tx-service-mantle.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-mantle.safe.global/check/
 status: up
 code: 200
-responseTime: 463
-lastUpdated: 2026-07-24T23:54:45.626Z
+responseTime: 556
+lastUpdated: 2026-07-25T07:50:49.786Z
 startTime: 2024-09-23T12:22:22.690Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mega-eth.yml
+++ b/history/safe-tx-service-mega-eth.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/mega/check/
 status: up
 code: 200
-responseTime: 465
-lastUpdated: 2026-07-24T23:54:55.128Z
+responseTime: 467
+lastUpdated: 2026-07-25T07:50:59.288Z
 startTime: 2025-11-19T09:51:44.285Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-monad-testnet.yml
+++ b/history/safe-tx-service-monad-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/monad-testnet/check/
 status: up
 code: 200
-responseTime: 466
-lastUpdated: 2026-07-24T23:54:54.128Z
+responseTime: 467
+lastUpdated: 2026-07-25T07:50:58.288Z
 startTime: 2025-11-19T09:51:43.117Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-monad.yml
+++ b/history/safe-tx-service-monad.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-monad.safe.global/check/
 status: up
 code: 200
-responseTime: 467
-lastUpdated: 2026-07-24T23:54:50.629Z
+responseTime: 466
+lastUpdated: 2026-07-25T07:50:54.787Z
 startTime: 2025-07-23T17:37:01.782Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-op-bnb.yml
+++ b/history/safe-tx-service-op-bnb.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-opbnb.safe.global/check/
 status: up
 code: 200
-responseTime: 468
-lastUpdated: 2026-07-24T23:54:51.131Z
+responseTime: 467
+lastUpdated: 2026-07-25T07:50:55.287Z
 startTime: 2025-08-27T12:42:16.466Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-optimism.yml
+++ b/history/safe-tx-service-optimism.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-optimism.safe.global/check/
 status: up
 code: 200
-responseTime: 464
-lastUpdated: 2026-07-24T23:54:42.126Z
+responseTime: 467
+lastUpdated: 2026-07-25T07:50:46.196Z
 startTime: 2022-04-27T08:51:31.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-peaq.yml
+++ b/history/safe-tx-service-peaq.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-peaq.safe.global/check/
 status: up
 code: 200
-responseTime: 463
-lastUpdated: 2026-07-24T23:54:49.627Z
+responseTime: 467
+lastUpdated: 2026-07-25T07:50:53.787Z
 startTime: 2025-06-19T11:04:40.586Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-pharos.yml
+++ b/history/safe-tx-service-pharos.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/pharos/check/
 status: up
 code: 200
-responseTime: 466
-lastUpdated: 2026-07-24T23:54:59.128Z
+responseTime: 468
+lastUpdated: 2026-07-25T07:51:03.288Z
 startTime: 2026-04-24T10:19:44.208Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-plasma.yml
+++ b/history/safe-tx-service-plasma.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/plasma/check/
 status: up
 code: 200
-responseTime: 464
-lastUpdated: 2026-07-24T23:54:52.627Z
+responseTime: 465
+lastUpdated: 2026-07-25T07:50:56.786Z
 startTime: 2025-11-19T09:51:41.442Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-polygon-matic.yml
+++ b/history/safe-tx-service-polygon-matic.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-polygon.safe.global/check/
 status: up
 code: 200
-responseTime: 447
-lastUpdated: 2026-07-24T23:54:38.376Z
+responseTime: 459
+lastUpdated: 2026-07-25T07:50:42.941Z
 startTime: 2021-08-05T10:30:18.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-robinhood-testnet.yml
+++ b/history/safe-tx-service-robinhood-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/robinhood-testnet/check/
 status: up
 code: 200
-responseTime: 466
-lastUpdated: 2026-07-24T23:54:58.628Z
+responseTime: 465
+lastUpdated: 2026-07-25T07:51:02.787Z
 startTime: 2026-04-13T11:40:23.659Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-scroll.yml
+++ b/history/safe-tx-service-scroll.yml
@@ -2,6 +2,6 @@ url: https://safe-transaction-scroll.safe.global/check/
 status: up
 code: 200
 responseTime: 467
-lastUpdated: 2026-07-24T23:54:44.128Z
+lastUpdated: 2026-07-25T07:50:48.195Z
 startTime: 2024-06-14T14:47:02.950Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-sepolia.yml
+++ b/history/safe-tx-service-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-sepolia.safe.global/check/
 status: up
 code: 200
-responseTime: 452
-lastUpdated: 2026-07-24T23:54:37.376Z
+responseTime: 580
+lastUpdated: 2026-07-25T07:50:41.939Z
 startTime: 2024-03-19T10:34:24.824Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-sonic.yml
+++ b/history/safe-tx-service-sonic.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-sonic.safe.global/check/
 status: up
 code: 200
-responseTime: 466
-lastUpdated: 2026-07-24T23:54:46.127Z
+responseTime: 468
+lastUpdated: 2026-07-25T07:50:50.287Z
 startTime: 2024-12-11T12:21:10.129Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-stable.yml
+++ b/history/safe-tx-service-stable.yml
@@ -2,6 +2,6 @@ url: https://api.safe.global/tx-service/stable/check/
 status: up
 code: 200
 responseTime: 465
-lastUpdated: 2026-07-24T23:54:53.628Z
+lastUpdated: 2026-07-25T07:50:57.787Z
 startTime: 2025-11-19T09:51:42.637Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-tempo-moderato.yml
+++ b/history/safe-tx-service-tempo-moderato.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/tempo-moderato/check/
 status: up
 code: 200
-responseTime: 464
-lastUpdated: 2026-07-24T23:54:57.127Z
+responseTime: 463
+lastUpdated: 2026-07-25T07:51:01.288Z
 startTime: 2026-03-13T10:03:54.843Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-tempo.yml
+++ b/history/safe-tx-service-tempo.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/tempo/check/
 status: up
 code: 200
-responseTime: 463
-lastUpdated: 2026-07-24T23:54:57.626Z
+responseTime: 477
+lastUpdated: 2026-07-25T07:51:01.797Z
 startTime: 2026-03-19T20:50:55.701Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-unichain.yml
+++ b/history/safe-tx-service-unichain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-unichain.safe.global/check/
 status: up
 code: 200
-responseTime: 463
-lastUpdated: 2026-07-24T23:54:47.127Z
+responseTime: 466
+lastUpdated: 2026-07-25T07:50:51.287Z
 startTime: 2025-02-04T11:44:48.395Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-whitechain-sepolia.yml
+++ b/history/safe-tx-service-whitechain-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/wch-sepolia/check/
 status: up
 code: 200
-responseTime: 466
-lastUpdated: 2026-07-24T23:55:02.629Z
+responseTime: 467
+lastUpdated: 2026-07-25T07:51:06.788Z
 startTime: 2026-07-16T13:17:58.007Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-x-layer.yml
+++ b/history/safe-tx-service-x-layer.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-xlayer.safe.global/check/
 status: up
 code: 200
-responseTime: 465
-lastUpdated: 2026-07-24T23:54:43.627Z
+responseTime: 467
+lastUpdated: 2026-07-25T07:50:47.696Z
 startTime: 2024-06-14T14:47:02.024Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-xdc.yml
+++ b/history/safe-tx-service-xdc.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-xdc.safe.global/check/
 status: up
 code: 200
-responseTime: 466
-lastUpdated: 2026-07-24T23:54:52.128Z
+responseTime: 382
+lastUpdated: 2026-07-25T07:50:56.288Z
 startTime: 2025-08-27T12:42:17.701Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-zk-sync-era-mainnet.yml
+++ b/history/safe-tx-service-zk-sync-era-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-zksync.safe.global/check/
 status: up
 code: 200
-responseTime: 463
-lastUpdated: 2026-07-24T23:54:43.127Z
+responseTime: 467
+lastUpdated: 2026-07-25T07:50:47.196Z
 startTime: 2024-03-19T10:34:31.311Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
Removes the Polygon zkEVM Mainnet Beta entry from uptime.safe.global as part of the network sunset (CLOUD-918). Shutdown was confirmed in #topic-networks. History files are bot-generated and left untouched.
