### PR TITLE
chore: Remove Botanix from uptime page

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -93,9 +93,6 @@ sites:
   - name: Safe Tx Service (OpBNB)
     url: https://safe-transaction-opbnb.safe.global/check/
     icon: https://safe-transaction-assets.safe.global/chains/204/chain_logo.png
-  - name: Safe Tx Service (Botanix)
-    url: https://safe-transaction-botanix.safe.global/check/
-    icon: https://safe-transaction-assets.safe.global/chains/3637/chain_logo.png
   - name: Safe Tx Service (XDC)
     url: https://safe-transaction-xdc.safe.global/check/
     icon: https://safe-transaction-assets.safe.global/chains/50/chain_logo.png

--- a/history/safe-client-gateway.yml
+++ b/history/safe-client-gateway.yml
@@ -1,7 +1,7 @@
 url: https://safe-client.safe.global/health/ready/
 status: up
 code: 200
-responseTime: 333
-lastUpdated: 2026-08-02T23:17:27.079Z
+responseTime: 452
+lastUpdated: 2026-08-03T18:39:23.590Z
 startTime: 2024-06-14T14:46:50.293Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-0g.yml
+++ b/history/safe-tx-service-0g.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/0g/check/
 status: up
 code: 200
-responseTime: 188
-lastUpdated: 2026-08-03T17:51:05.632Z
+responseTime: 405
+lastUpdated: 2026-08-03T18:39:44.398Z
 startTime: 2025-11-19T09:51:42.016Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-adi.yml
+++ b/history/safe-tx-service-adi.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/adi/check/
 status: up
 code: 200
-responseTime: 183
-lastUpdated: 2026-08-03T17:52:03.911Z
+responseTime: 473
+lastUpdated: 2026-08-03T18:39:54.398Z
 startTime: 2026-07-31T10:53:19.488Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arbitrum.yml
+++ b/history/safe-tx-service-arbitrum.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-arbitrum.safe.global/check/
 status: up
 code: 200
-responseTime: 462
-lastUpdated: 2026-08-03T17:49:50.656Z
+responseTime: 531
+lastUpdated: 2026-08-03T18:39:32.433Z
 startTime: 2021-08-05T10:30:22.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arc-testnet.yml
+++ b/history/safe-tx-service-arc-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/arc-testnet/check/
 status: up
 code: 200
-responseTime: 181
-lastUpdated: 2026-08-03T17:51:20.448Z
+responseTime: 445
+lastUpdated: 2026-08-03T18:39:46.897Z
 startTime: 2026-01-16T19:30:22.108Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-arc.yml
+++ b/history/safe-tx-service-arc.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/arc/check/
 status: up
 code: 200
-responseTime: 188
-lastUpdated: 2026-08-03T17:51:46.765Z
+responseTime: 473
+lastUpdated: 2026-08-03T18:39:51.399Z
 startTime: 2026-05-22T09:34:40.849Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-aurora.yml
+++ b/history/safe-tx-service-aurora.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-aurora.safe.global/check/
 status: up
 code: 200
-responseTime: 448
-lastUpdated: 2026-08-03T17:50:00.228Z
+responseTime: 470
+lastUpdated: 2026-08-03T18:39:33.975Z
 startTime: 2024-03-19T10:34:30.573Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-avalanche.yml
+++ b/history/safe-tx-service-avalanche.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-avalanche.safe.global/check/
 status: up
 code: 200
-responseTime: 625
-lastUpdated: 2026-08-03T17:49:54.046Z
+responseTime: 473
+lastUpdated: 2026-08-03T18:39:32.934Z
 startTime: 2022-03-25T11:57:26.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-base-mainnet.yml
+++ b/history/safe-tx-service-base-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-base.safe.global/check/
 status: up
 code: 200
-responseTime: 438
-lastUpdated: 2026-08-03T17:49:41.268Z
+responseTime: 473
+lastUpdated: 2026-08-03T18:39:26.922Z
 startTime: 2024-06-14T14:46:55.924Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-base-sepolia.yml
+++ b/history/safe-tx-service-base-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-base-sepolia.safe.global/check/
 status: up
 code: 200
-responseTime: 409
-lastUpdated: 2026-08-03T17:49:44.389Z
+responseTime: 473
+lastUpdated: 2026-08-03T18:39:27.423Z
 startTime: 2024-03-19T10:34:27.349Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-berachain.yml
+++ b/history/safe-tx-service-berachain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-berachain.safe.global/check/
 status: up
 code: 200
-responseTime: 492
-lastUpdated: 2026-08-03T17:50:31.664Z
+responseTime: 461
+lastUpdated: 2026-08-03T18:39:39.152Z
 startTime: 2025-02-17T09:20:55.646Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-binance-smart-chain.yml
+++ b/history/safe-tx-service-binance-smart-chain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-bsc.safe.global/check/
 status: up
 code: 200
-responseTime: 444
-lastUpdated: 2026-08-03T17:49:35.123Z
+responseTime: 631
+lastUpdated: 2026-08-03T18:39:25.849Z
 startTime: 2021-08-05T10:30:17.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-botchain.yml
+++ b/history/safe-tx-service-botchain.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/bot/check/
 status: up
 code: 200
-responseTime: 180
-lastUpdated: 2026-08-03T17:51:58.059Z
+responseTime: 471
+lastUpdated: 2026-08-03T18:39:53.396Z
 startTime: 2026-07-07T09:27:14.783Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-celo-sepolia.yml
+++ b/history/safe-tx-service-celo-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/celo-sep/check/
 status: up
 code: 200
-responseTime: 207
-lastUpdated: 2026-08-03T17:51:43.935Z
+responseTime: 473
+lastUpdated: 2026-08-03T18:39:50.899Z
 startTime: 2026-04-28T07:36:23.579Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-celo.yml
+++ b/history/safe-tx-service-celo.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-celo.safe.global/check/
 status: up
 code: 200
-responseTime: 507
-lastUpdated: 2026-08-03T17:49:47.636Z
+responseTime: 4424
+lastUpdated: 2026-08-03T18:39:31.874Z
 startTime: 2023-05-23T15:39:32.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-chiado.yml
+++ b/history/safe-tx-service-chiado.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-chiado.safe.global/check/
 status: up
 code: 200
-responseTime: 411
-lastUpdated: 2026-08-03T17:50:16.204Z
+responseTime: 603
+lastUpdated: 2026-08-03T18:39:36.652Z
 startTime: 2024-08-16T10:52:40.346Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-codex.yml
+++ b/history/safe-tx-service-codex.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-codex.safe.global/check/
 status: up
 code: 200
-responseTime: 490
-lastUpdated: 2026-08-03T17:50:46.644Z
+responseTime: 471
+lastUpdated: 2026-08-03T18:39:41.867Z
 startTime: 2025-07-15T12:51:17.948Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-creditcoin.yml
+++ b/history/safe-tx-service-creditcoin.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/ctc/check/
 status: up
 code: 200
-responseTime: 388
-lastUpdated: 2026-08-03T17:51:23.578Z
+responseTime: 473
+lastUpdated: 2026-08-03T18:39:47.398Z
 startTime: 2026-03-06T09:26:54.038Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-fluent.yml
+++ b/history/safe-tx-service-fluent.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/fluent/check/
 status: up
 code: 200
-responseTime: 213
-lastUpdated: 2026-08-03T17:51:35.446Z
+responseTime: 471
+lastUpdated: 2026-08-03T18:39:49.397Z
 startTime: 2026-04-08T07:35:21.962Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-gnosis-chain.yml
+++ b/history/safe-tx-service-gnosis-chain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-gnosis-chain.safe.global/check/
 status: up
 code: 200
-responseTime: 618
-lastUpdated: 2026-08-03T17:49:28.487Z
+responseTime: 471
+lastUpdated: 2026-08-03T18:39:24.693Z
 startTime: 2022-12-21T17:20:44.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-hemi.yml
+++ b/history/safe-tx-service-hemi.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-hemi.safe.global/check/
 status: up
 code: 200
-responseTime: 529
-lastUpdated: 2026-08-03T17:50:37.618Z
+responseTime: 485
+lastUpdated: 2026-08-03T18:39:40.367Z
 startTime: 2025-04-29T10:31:54.263Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-hyper-evm.yml
+++ b/history/safe-tx-service-hyper-evm.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/hyper/check/
 status: up
 code: 200
-responseTime: 302
-lastUpdated: 2026-08-03T17:51:14.680Z
+responseTime: 471
+lastUpdated: 2026-08-03T18:39:45.897Z
 startTime: 2025-11-19T09:51:43.815Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-ink.yml
+++ b/history/safe-tx-service-ink.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-ink.safe.global/check/
 status: up
 code: 200
-responseTime: 494
-lastUpdated: 2026-08-03T17:50:25.427Z
+responseTime: 471
+lastUpdated: 2026-08-03T18:39:38.152Z
 startTime: 2024-12-12T17:15:05.125Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-kaia.yml
+++ b/history/safe-tx-service-kaia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/kaia/check/
 status: up
 code: 200
-responseTime: 196
-lastUpdated: 2026-08-03T17:51:55.044Z
+responseTime: 471
+lastUpdated: 2026-08-03T18:39:52.897Z
 startTime: 2026-06-12T08:10:32.754Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-kairos.yml
+++ b/history/safe-tx-service-kairos.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/kairos/check/
 status: up
 code: 200
-responseTime: 218
-lastUpdated: 2026-08-03T17:51:52.404Z
+responseTime: 455
+lastUpdated: 2026-08-03T18:39:52.399Z
 startTime: 2026-05-28T09:18:51.609Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-katana.yml
+++ b/history/safe-tx-service-katana.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-katana.safe.global/check/
 status: up
 code: 200
-responseTime: 400
-lastUpdated: 2026-08-03T17:50:40.499Z
+responseTime: 472
+lastUpdated: 2026-08-03T18:39:40.867Z
 startTime: 2025-06-12T12:51:37.947Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-lens.yml
+++ b/history/safe-tx-service-lens.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-lens.safe.global/check/
 status: up
 code: 200
-responseTime: 426
-lastUpdated: 2026-08-03T17:50:34.548Z
+responseTime: 474
+lastUpdated: 2026-08-03T18:39:39.653Z
 startTime: 2025-04-29T10:31:53.750Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-linea.yml
+++ b/history/safe-tx-service-linea.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-linea.safe.global/check/
 status: up
 code: 200
-responseTime: 1028
-lastUpdated: 2026-08-03T17:50:13.069Z
+responseTime: 491
+lastUpdated: 2026-08-03T18:39:36.022Z
 startTime: 2024-08-13T14:27:58.910Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mainnet.yml
+++ b/history/safe-tx-service-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-mainnet.safe.global/check/
 status: up
 code: 200
-responseTime: 1275
-lastUpdated: 2026-08-03T17:49:25.201Z
+responseTime: 549
+lastUpdated: 2026-08-03T18:39:24.193Z
 startTime: 2021-08-05T10:30:13.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mantle-sepolia.yml
+++ b/history/safe-tx-service-mantle-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/mnt-sep/check/
 status: up
 code: 200
-responseTime: 220
-lastUpdated: 2026-08-03T17:51:26.396Z
+responseTime: 473
+lastUpdated: 2026-08-03T18:39:47.898Z
 startTime: 2026-03-09T14:14:37.684Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mantle.yml
+++ b/history/safe-tx-service-mantle.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-mantle.safe.global/check/
 status: up
 code: 200
-responseTime: 532
-lastUpdated: 2026-08-03T17:50:19.387Z
+responseTime: 474
+lastUpdated: 2026-08-03T18:39:37.153Z
 startTime: 2024-09-23T12:22:22.690Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-mega-eth.yml
+++ b/history/safe-tx-service-mega-eth.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/mega/check/
 status: up
 code: 200
-responseTime: 181
-lastUpdated: 2026-08-03T17:51:17.392Z
+responseTime: 496
+lastUpdated: 2026-08-03T18:39:46.420Z
 startTime: 2025-11-19T09:51:44.285Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-monad-testnet.yml
+++ b/history/safe-tx-service-monad-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/monad-testnet/check/
 status: up
 code: 200
-responseTime: 222
-lastUpdated: 2026-08-03T17:51:11.609Z
+responseTime: 473
+lastUpdated: 2026-08-03T18:39:45.399Z
 startTime: 2025-11-19T09:51:43.117Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-monad.yml
+++ b/history/safe-tx-service-monad.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-monad.safe.global/check/
 status: up
 code: 200
-responseTime: 608
-lastUpdated: 2026-08-03T17:50:49.954Z
+responseTime: 474
+lastUpdated: 2026-08-03T18:39:42.368Z
 startTime: 2025-07-23T17:37:01.782Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-op-bnb.yml
+++ b/history/safe-tx-service-op-bnb.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-opbnb.safe.global/check/
 status: up
 code: 200
-responseTime: 642
-lastUpdated: 2026-08-03T17:50:53.220Z
+responseTime: 502
+lastUpdated: 2026-08-03T18:39:42.898Z
 startTime: 2025-08-27T12:42:16.466Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-optimism.yml
+++ b/history/safe-tx-service-optimism.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-optimism.safe.global/check/
 status: up
 code: 200
-responseTime: 648
-lastUpdated: 2026-08-03T17:49:57.228Z
+responseTime: 398
+lastUpdated: 2026-08-03T18:39:33.478Z
 startTime: 2022-04-27T08:51:31.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-peaq.yml
+++ b/history/safe-tx-service-peaq.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-peaq.safe.global/check/
 status: up
 code: 200
-responseTime: 405
-lastUpdated: 2026-08-03T17:50:43.523Z
+responseTime: 472
+lastUpdated: 2026-08-03T18:39:41.367Z
 startTime: 2025-06-19T11:04:40.586Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-pharos.yml
+++ b/history/safe-tx-service-pharos.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/pharos/check/
 status: up
 code: 200
-responseTime: 249
-lastUpdated: 2026-08-03T17:51:41.168Z
+responseTime: 473
+lastUpdated: 2026-08-03T18:39:50.398Z
 startTime: 2026-04-24T10:19:44.208Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-plasma.yml
+++ b/history/safe-tx-service-plasma.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/plasma/check/
 status: up
 code: 200
-responseTime: 242
-lastUpdated: 2026-08-03T17:51:02.728Z
+responseTime: 539
+lastUpdated: 2026-08-03T18:39:43.965Z
 startTime: 2025-11-19T09:51:41.442Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-polygon-matic.yml
+++ b/history/safe-tx-service-polygon-matic.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-polygon.safe.global/check/
 status: up
 code: 200
-responseTime: 488
-lastUpdated: 2026-08-03T17:49:38.148Z
+responseTime: 537
+lastUpdated: 2026-08-03T18:39:26.421Z
 startTime: 2021-08-05T10:30:18.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-robinhood-testnet.yml
+++ b/history/safe-tx-service-robinhood-testnet.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/robinhood-testnet/check/
 status: up
 code: 200
-responseTime: 181
-lastUpdated: 2026-08-03T17:51:38.484Z
+responseTime: 473
+lastUpdated: 2026-08-03T18:39:49.898Z
 startTime: 2026-04-13T11:40:23.659Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-robinhood.yml
+++ b/history/safe-tx-service-robinhood.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/robinhood/check/
 status: up
 code: 200
-responseTime: 380
-lastUpdated: 2026-08-03T17:51:49.626Z
+responseTime: 469
+lastUpdated: 2026-08-03T18:39:51.896Z
 startTime: 2026-07-28T15:20:28.500Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-scroll.yml
+++ b/history/safe-tx-service-scroll.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-scroll.safe.global/check/
 status: up
 code: 200
-responseTime: 403
-lastUpdated: 2026-08-03T17:50:09.391Z
+responseTime: 472
+lastUpdated: 2026-08-03T18:39:35.491Z
 startTime: 2024-06-14T14:47:02.950Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-sepolia.yml
+++ b/history/safe-tx-service-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-sepolia.safe.global/check/
 status: up
 code: 200
-responseTime: 760
-lastUpdated: 2026-08-03T17:49:31.932Z
+responseTime: 471
+lastUpdated: 2026-08-03T18:39:25.191Z
 startTime: 2024-03-19T10:34:24.824Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-sonic.yml
+++ b/history/safe-tx-service-sonic.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-sonic.safe.global/check/
 status: up
 code: 200
-responseTime: 491
-lastUpdated: 2026-08-03T17:50:22.420Z
+responseTime: 474
+lastUpdated: 2026-08-03T18:39:37.654Z
 startTime: 2024-12-11T12:21:10.129Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-stable.yml
+++ b/history/safe-tx-service-stable.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/stable/check/
 status: up
 code: 200
-responseTime: 185
-lastUpdated: 2026-08-03T17:51:08.680Z
+responseTime: 473
+lastUpdated: 2026-08-03T18:39:44.899Z
 startTime: 2025-11-19T09:51:42.637Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-tempo-moderato.yml
+++ b/history/safe-tx-service-tempo-moderato.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/tempo-moderato/check/
 status: up
 code: 200
-responseTime: 213
-lastUpdated: 2026-08-03T17:51:29.626Z
+responseTime: 474
+lastUpdated: 2026-08-03T18:39:48.399Z
 startTime: 2026-03-13T10:03:54.843Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-tempo.yml
+++ b/history/safe-tx-service-tempo.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/tempo/check/
 status: up
 code: 200
-responseTime: 218
-lastUpdated: 2026-08-03T17:51:32.639Z
+responseTime: 471
+lastUpdated: 2026-08-03T18:39:48.898Z
 startTime: 2026-03-19T20:50:55.701Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-unichain.yml
+++ b/history/safe-tx-service-unichain.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-unichain.safe.global/check/
 status: up
 code: 200
-responseTime: 433
-lastUpdated: 2026-08-03T17:50:28.515Z
+responseTime: 405
+lastUpdated: 2026-08-03T18:39:38.663Z
 startTime: 2025-02-04T11:44:48.395Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-whitechain-sepolia.yml
+++ b/history/safe-tx-service-whitechain-sepolia.yml
@@ -1,7 +1,7 @@
 url: https://api.safe.global/tx-service/wch-sepolia/check/
 status: up
 code: 200
-responseTime: 221
-lastUpdated: 2026-08-03T17:52:00.998Z
+responseTime: 474
+lastUpdated: 2026-08-03T18:39:53.898Z
 startTime: 2026-07-16T13:17:58.007Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-x-layer.yml
+++ b/history/safe-tx-service-x-layer.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-xlayer.safe.global/check/
 status: up
 code: 200
-responseTime: 496
-lastUpdated: 2026-08-03T17:50:06.315Z
+responseTime: 452
+lastUpdated: 2026-08-03T18:39:34.991Z
 startTime: 2024-06-14T14:47:02.024Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-xdc.yml
+++ b/history/safe-tx-service-xdc.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-xdc.safe.global/check/
 status: up
 code: 200
-responseTime: 730
-lastUpdated: 2026-08-03T17:50:59.808Z
+responseTime: 472
+lastUpdated: 2026-08-03T18:39:43.399Z
 startTime: 2025-08-27T12:42:17.701Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/safe-tx-service-zk-sync-era-mainnet.yml
+++ b/history/safe-tx-service-zk-sync-era-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://safe-transaction-zksync.safe.global/check/
 status: up
 code: 200
-responseTime: 393
-lastUpdated: 2026-08-03T17:50:03.199Z
+responseTime: 487
+lastUpdated: 2026-08-03T18:39:34.490Z
 startTime: 2024-03-19T10:34:31.311Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
## What

Remove the `Safe Tx Service (Botanix)` entry from the public uptime page. The Botanix chain (3637) has been shut down.

One file, three lines. `sites` goes 54 → 53.

## Why

The monitored URL `https://safe-transaction-botanix.safe.global/check/` returns a 308 and the service behind it is dead — the tx-service app and its RDS are being removed — so this would sit permanently red on uptime.safe.global.

## Note

Replaces #19577, which became CONFLICTING. That branch was cut from a stale local `origin/master` (this repo is a single-branch clone, so the branch ref never fetched) and therefore carried divergent upptime-bot files — `README.md`, `history/*.yml`, `history/summary.json` — which the bot has since rewritten on master. This branch is cut from current master and touches only `.upptimerc.yml`.

`history/safe-tx-service-botanix.yml`, `history/summary.json` and `README.md` are bot-generated and deliberately left for the bot to reconcile.

Part of the Botanix decommission: legacy-safe-argocd-mgmt#482, legacy-safe-account-mgmt#223, platform-team-datadog-tf#90.
